### PR TITLE
Sequence numbers

### DIFF
--- a/audio_msgs/msg/Audio.msg
+++ b/audio_msgs/msg/Audio.msg
@@ -3,11 +3,11 @@
 std_msgs/Header header  # Header timestamp should be acquisition time the beginning of the buffer
                         # Header frame_id should be meaningful to the location of the transducers
 
-uint32 frames           # Number of time intervals in this buffer
+uint64 seq_num          # accumulator of number of frames that came before this message
+
+uint32 frames           # Number of sample-rate intervals in this buffer
 uint32 channels         # number of channels of audio
-
 int32 sample_rate       # the sample rate of the audio in Hz (number type following Gstreamer)
-
 
                         # Values for encoding should follow Image message OpenCV convention
 string encoding         # Encoding of samples, channel meaning, ordering, etc

--- a/gst_bridge/include/gst_bridge/rosaudiosink.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosink.h
@@ -61,7 +61,7 @@ struct _Rosaudiosink
   gchar* init_caps; //a hack to allow skipping preroll
 
   GstAudioInfo audio_info;
-  
+  uint64_t msg_seq_num;
 };
 
 struct _RosaudiosinkClass

--- a/gst_bridge/include/gst_bridge/rosaudiosrc.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosrc.h
@@ -62,6 +62,7 @@ struct _Rosaudiosrc
   GstClockTimeDiff ros_clock_offset;
 
   GstAudioInfo audio_info;
+  uint64_t msg_seq_num;
 };
 
 struct _RosaudiosrcClass

--- a/gst_bridge/src/rosaudiosink.cpp
+++ b/gst_bridge/src/rosaudiosink.cpp
@@ -329,6 +329,7 @@ static GstStateChangeReturn rosaudiosink_change_state (GstElement * element, Gst
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
     {
       sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->clock);
+      sink->msg_seq_num = 0;
       break;
     }
     case GST_STATE_CHANGE_READY_TO_PAUSED:
@@ -475,6 +476,9 @@ static GstFlowReturn rosaudiosink_render (GstBaseSink * base_sink, GstBuffer * b
   gst_buffer_map (buf, &info, GST_MAP_READ);
   msg.data.assign(info.data, info.data+info.size);
   msg.frames = info.size/GST_AUDIO_INFO_BPF(&(sink->audio_info));
+  msg.seq_num = sink->msg_seq_num;
+  sink->msg_seq_num += msg.frames;
+
   gst_buffer_unmap (buf, &info);
 
   //publish

--- a/gst_bridge/src/rosaudiosrc.cpp
+++ b/gst_bridge/src/rosaudiosrc.cpp
@@ -633,6 +633,7 @@ static GstFlowReturn rosaudiosrc_create (GstBaseSrc * base_src, guint64 offset, 
   }
 
   auto msg = rosaudiosrc_wait_for_msg(src);
+  // XXX check sequence number and pad the buffer
 
   length = msg->data.size();
   if (*buf == NULL) {


### PR DESCRIPTION
Add a sequence number to audio messages to precisely track lost frames, and allow audio messages to overlap after filters