### PR TITLE
use SensorDataQoS

### DIFF
--- a/gst_bridge/src/rosaudiosink.cpp
+++ b/gst_bridge/src/rosaudiosink.cpp
@@ -365,7 +365,7 @@ static gboolean rosaudiosink_open (Rosaudiosink * sink)
   rclcpp::NodeOptions opts = rclcpp::NodeOptions();
   opts.context(sink->ros_context); //set a context to generate the node in
   sink->node = std::make_shared<rclcpp::Node>(std::string(sink->node_name), std::string(sink->node_namespace), opts);
-  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS();  //XXX add a parameter for overrides
+  rclcpp::QoS qos = rclcpp::SensorDataQoS().reliable();  //XXX add a parameter for overrides
   sink->pub = sink->node->create_publisher<audio_msgs::msg::Audio>(sink->pub_topic, qos);
   sink->logger = sink->node->get_logger();
   sink->clock = sink->node->get_clock();

--- a/gst_bridge/src/rosaudiosrc.cpp
+++ b/gst_bridge/src/rosaudiosrc.cpp
@@ -437,7 +437,7 @@ static gboolean rosaudiosrc_open (Rosaudiosrc * src)
   // ROS can't cope with some forms of std::bind being passed as subscriber callbacks,
   // lambdas seem to be the preferred case for these instances
   auto cb = [src] (audio_msgs::msg::Audio::ConstSharedPtr msg){rosaudiosrc_sub_cb(src, msg);};
-  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS();  //XXX add a parameter for overrides
+  rclcpp::QoS qos = rclcpp::SensorDataQoS();  //XXX add a parameter for overrides
   src->sub = src->node->create_subscription<audio_msgs::msg::Audio>(src->sub_topic, qos, cb);
 
   src->logger = src->node->get_logger();

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -369,7 +369,7 @@ static gboolean rosimagesink_open (Rosimagesink * sink)
   rclcpp::NodeOptions opts = rclcpp::NodeOptions();
   opts.context(sink->ros_context); //set a context to generate the node in
   sink->node = std::make_shared<rclcpp::Node>(std::string(sink->node_name), std::string(sink->node_namespace), opts);
-  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS();  //XXX add a parameter for overrides
+  rclcpp::QoS qos = rclcpp::SensorDataQoS().reliable();  //XXX add a parameter for overrides
   sink->pub = sink->node->create_publisher<sensor_msgs::msg::Image>(sink->pub_topic, qos);
   sink->logger = sink->node->get_logger();
   sink->clock = sink->node->get_clock();

--- a/gst_bridge/src/rosimagesrc.cpp
+++ b/gst_bridge/src/rosimagesrc.cpp
@@ -471,7 +471,7 @@ static gboolean rosimagesrc_open (Rosimagesrc * src)
   // ROS can't cope with some forms of std::bind being passed as subscriber callbacks,
   // lambdas seem to be the preferred case for these instances
   auto cb = [src] (sensor_msgs::msg::Image::ConstSharedPtr msg){rosimagesrc_sub_cb(src, msg);};
-  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS();  //XXX add a parameter for overrides
+  rclcpp::QoS qos = rclcpp::SensorDataQoS();  //XXX add a parameter for overrides
   src->sub = src->node->create_subscription<sensor_msgs::msg::Image>(src->sub_topic, qos, cb);
 
   src->logger = src->node->get_logger();


### PR DESCRIPTION
Following discussions in gazebo, conventions seem to suggest using SensorDataQoS for sensor data, but using `.reliable()` for publishers.
Audio over the network may require longer history buffers, this still needs an override mechanism