### PR TITLE
Provide parent classes to handle repeated ROS details

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ It should be easy to pass data between GStreamer and ROS without loss of informa
 ### gst_bridge
 A ROS2 package containing a GStreamer plugin, and simple format conversions (similar goal to cv-bridge).
 The GStreamer plugin has source and sink elements that appear on the ROS graph as independent ROS nodes.
-These nodes can be configured by passing parameters via the GStreamer pipeline, and can be assigned names, namespaces, and frame_ids.  These nodes can also be launched using gst-launch, or instantiated in pipelines inside other applications.
+These nodes can be configured by passing parameters via the GStreamer pipeline, and can be assigned names, namespaces, and frame_ids.  These nodes can also be launched using gst-launch, or instantiated in pipelines inside other applications.  
+Currently implemented are `rosaudiosink`, `rosaudiosrc`, `rosimagesink`, and `rosimagesrc`
+Inspect them with `gst-inspect-1.0 --gst-plugin-path=install/gst_bridge/lib/gst_bridge/ rosaudiosink`
 
 ### gst_pipeline
 A ROS2 package with a collection of python scripts that handle gstreamer pipeline generation within a ROS node.
@@ -38,8 +40,8 @@ A gstreamer pipeline can comfortably manage multiple independent streams, so onl
 
 The sources and sinks should be implemented as gstreamer elements for a couple of reasons.\
 GStreamer elements are intended to be compact and versatile, this encourages reduction of code complexity.
-Ros elements would allow any GStreamer capable application to interact directly with ROS.  `gst-launch 'rosimagesrc topic="image_raw" ! gamma gamma=2.0 ! rosimagesink topic="image_gamma_corrected'` executed from the command line would apply a gamma correction to an image topic.
-GStreamer is able to pre-allocate memory from down-stream elements and pass it upstream, enabling sink elements to benefit from the ROS zero-copy API.
+Ros elements would allow any GStreamer capable application to interact directly with ROS.  `gst-launch --gst-plugin-path=install/gst_bridge/lib/gst_bridge/ 'rosimagesrc topic="image_raw" ! gamma gamma=2.0 ! rosimagesink topic="image_gamma_corrected'` executed from the command line would apply a gamma correction to an image topic.
+
 
 It is possible to build this using the gstreamer appsrc/appsink API, but it requires re-implementation of the whole plugin architecture that GStreamer implements so well.
 audio-common and gs-cam have good examples of the gstreamer appsrc/appsink API.  
@@ -50,3 +52,4 @@ audio-common and gs-cam have good examples of the gstreamer appsrc/appsink API.
 * Pipeline elements should optionally provide a clock source to ROS, to allow the use of pipeline time generated from an external hardware clock.
 * Image format equivalences between GStreamer and ROS need more testing
 * Examples of pipelines that control element parameters from ROS topics
+* exploration of allocator APIs so that gstreamer can preallocate buffers from the downstream DDS

--- a/gst_bridge/CMakeLists.txt
+++ b/gst_bridge/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(rosgstbridge SHARED
   src/rosgstbridgeplugin.cpp 
   src/gst_bridge.cpp
   src/rosbasesink.cpp
+  src/rosbasesrc.cpp
   src/rosaudiosink.cpp
   src/rosimagesink.cpp
   src/rosaudiosrc.cpp

--- a/gst_bridge/CMakeLists.txt
+++ b/gst_bridge/CMakeLists.txt
@@ -60,6 +60,7 @@ find_package(builtin_interfaces REQUIRED)
 add_library(rosgstbridge SHARED
   src/rosgstbridgeplugin.cpp 
   src/gst_bridge.cpp
+  src/rosbasesink.cpp
   src/rosaudiosink.cpp
   src/rosimagesink.cpp
   src/rosaudiosrc.cpp

--- a/gst_bridge/include/gst_bridge/gst_bridge.h
+++ b/gst_bridge/include/gst_bridge/gst_bridge.h
@@ -18,7 +18,14 @@
 #include <audio_msgs/msg/audio.hpp>
 
 #define GST_BRIDGE_GST_VIDEO_FORMAT_LIST "{ GRAY8, GRAY16_LE, RGB, BGR, RGBA, BGRA }"
-#define GST_BRIDGE_GST_AUDIO_FORMAT_LIST "S16LE"    // "Any"
+#define GST_BRIDGE_GST_AUDIO_FORMAT_LIST "{ S8, U8, S16LE, U16LE, S32LE, U32LE, F32LE, F64LE }"    // only well behaved formats
+
+// The following audio formats are theoretically ok, but might be more throuble than they're worth.
+// 
+// these formats need endian conversion on popular platforms
+//     S16BE, U16BE, S24_32BE, U24_32BE, S32BE, U32BE, S24BE, U24BE, S20BE, U20BE, S18BE, U18BE, F32BE, F64BE
+// these formats have odd packing and need thorough testing
+//     S24_32LE, U24_32LE, S24LE, U24LE, S20LE, U20LE, S18LE, U18LE, 
 
 
 #define ROS_IMAGE_MSG_CAPS                            \
@@ -44,6 +51,11 @@
   "stream-format = (string) byte-stream, "            \
   "alignment = (string) nal, "                        \
   "profile = (string) { constrained-baseline, baseline, main, high }"
+
+// XXX support source from "text/plain" for pocketsphinx
+// XXX support sink to "text/x-raw,{ (string)pango-markup, (string)utf8 }" for textoverlay
+// XXX support src and sink "ANY" like filesink and filesrc, (emit a stamped byte string, with a gst caps string as meta)
+
 
 
 namespace gst_bridge

--- a/gst_bridge/include/gst_bridge/gst_bridge.h
+++ b/gst_bridge/include/gst_bridge/gst_bridge.h
@@ -62,7 +62,7 @@ namespace gst_bridge
 {
 //measure the difference between ROS and GST time
 //raw sampling of the clocks seems to be stable within about 10uS
-GstClockTimeDiff sample_clock_offset(GstClock* gst_clock, rclcpp::Clock::SharedPtr ros_clock);
+GstClockTimeDiff sample_clock_offset(GstClock* gst_clock, rclcpp::Time stream_start);
 
 // convert between ROS and GST types
 GstVideoFormat getGstVideoFormat(const std::string & encoding);

--- a/gst_bridge/include/gst_bridge/rosaudiosink.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosink.h
@@ -23,6 +23,7 @@
 #include <gst/audio/audio-format.h>
 #include <gst/base/gstbasesink.h>
 #include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesink.h>
 
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
@@ -42,23 +43,14 @@ typedef struct _RosaudiosinkClass RosaudiosinkClass;
 
 struct _Rosaudiosink
 {
-  GstBaseSink parent;
-  gchar* node_name;
-  gchar* node_namespace;
+  RosBaseSink parent;
+
   gchar* pub_topic;
-
-  rclcpp::Context::SharedPtr ros_context;
-  rclcpp::executor::Executor::SharedPtr ros_executor;
-  rclcpp::Node::SharedPtr node;
-  rclcpp::Logger logger;
-  rclcpp::Clock::SharedPtr clock;
-  GstClockTimeDiff ros_clock_offset;
-
-  rclcpp::Publisher<audio_msgs::msg::Audio>::SharedPtr pub;
-
   gchar* frame_id;
   gchar* encoding; //msg encoding override string (for hacking)
   gchar* init_caps; //a hack to allow skipping preroll
+
+  rclcpp::Publisher<audio_msgs::msg::Audio>::SharedPtr pub;
 
   GstAudioInfo audio_info;
   uint64_t msg_seq_num;
@@ -66,7 +58,7 @@ struct _Rosaudiosink
 
 struct _RosaudiosinkClass
 {
-  GstBaseSinkClass parent_class;
+  RosBaseSinkClass parent_class;
 
   // stick member function pointers here
   // along with member function pointers for signal handlers

--- a/gst_bridge/include/gst_bridge/rosaudiosink.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosink.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2020 FIXME <fixme@example.com>
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/gst_bridge/include/gst_bridge/rosaudiosrc.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosrc.h
@@ -23,6 +23,7 @@
 #include <gst/audio/audio-format.h>
 #include <gst/base/gstbasesrc.h>
 #include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesrc.h>
 
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
@@ -42,9 +43,7 @@ typedef struct _RosaudiosrcClass RosaudiosrcClass;
 
 struct _Rosaudiosrc
 {
-  GstBaseSrc parent;
-  gchar* node_name;
-  gchar* node_namespace;
+  RosBaseSrc parent;
   gchar* sub_topic;
   gchar* frame_id;
   gchar* encoding;
@@ -53,13 +52,7 @@ struct _Rosaudiosrc
   bool msg_init;
   std::promise<audio_msgs::msg::Audio::ConstSharedPtr> new_msg;
 
-  rclcpp::Context::SharedPtr ros_context;
-  rclcpp::executor::Executor::SharedPtr ros_executor;
-  rclcpp::Node::SharedPtr node;
   rclcpp::Subscription<audio_msgs::msg::Audio>::SharedPtr sub;
-  rclcpp::Logger logger;
-  rclcpp::Clock::SharedPtr clock;
-  GstClockTimeDiff ros_clock_offset;
 
   GstAudioInfo audio_info;
   uint64_t msg_seq_num;
@@ -67,7 +60,7 @@ struct _Rosaudiosrc
 
 struct _RosaudiosrcClass
 {
-  GstBaseSrcClass parent_class;
+  RosBaseSrcClass parent_class;
 
   // stick member function pointers here
   // along with member function pointers for signal handlers

--- a/gst_bridge/include/gst_bridge/rosaudiosrc.h
+++ b/gst_bridge/include/gst_bridge/rosaudiosrc.h
@@ -28,7 +28,9 @@
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
 #include <audio_msgs/msg/audio.hpp>
-
+#include <queue>  // std::queue
+#include <mutex>  // std::mutex, std::unique_lock
+#include <condition_variable> // std::condition_variable
 
 G_BEGIN_DECLS
 
@@ -50,7 +52,12 @@ struct _Rosaudiosrc
   gchar* init_caps;
 
   bool msg_init;
-  std::promise<audio_msgs::msg::Audio::ConstSharedPtr> new_msg;
+
+  // XXX this is too much boilerplate.
+  size_t msg_queue_max;
+  std::queue<audio_msgs::msg::Audio::ConstSharedPtr> msg_queue;
+  std::mutex msg_queue_mtx;
+  std::condition_variable msg_queue_cv;
 
   rclcpp::Subscription<audio_msgs::msg::Audio>::SharedPtr sub;
 

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -28,7 +28,6 @@
 
 
 G_BEGIN_DECLS
-//XXX need to declare as virtual / subclassable
 #define GST_TYPE_ROS_BASE_SINK   (rosbasesink_get_type())
 #define GST_ROS_BASE_SINK(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_ROS_BASE_SINK,RosBaseSink))
 #define GST_ROS_BASE_SINK_CAST(obj)        ((RosBaseSink*)obj)
@@ -51,6 +50,7 @@ struct _RosBaseSink
   rclcpp::Node::SharedPtr node;
   rclcpp::Logger logger;
   rclcpp::Clock::SharedPtr clock;
+  rclcpp::Time stream_start;
   GstClockTimeDiff ros_clock_offset;
 
   rclcpp::QoS qos_override; //passed in to adjust pub qos
@@ -87,41 +87,12 @@ struct _RosBaseSinkClass
 
 
   /*
-   * gstreamer asks us for a caps filter for downstream to choose out of
-   *
-   */
-  GstCaps*  (*get_caps) (RosBaseSink * sink, GstCaps * filter);
-
-
-  /*
-   * gstreamer asks us for a caps filter for downstream to choose out of
-   *
-   */
-  gboolean (*query) (RosBaseSink * sink, GstQuery * query);
-
-
-  /*
    * publish the message
    * msg_time is derived from buf and offset by rostime at pipeline playtime
    * rosbasesink will calculate msg_time, you can bypass that by using gstbasesink's render() instead
    */
   GstFlowReturn (*render) (RosBaseSink * base_sink, GstBuffer * buf, rclcpp::Time msg_time);
 
-
-  /*
-   * gstreamer wants to set a named property and rosbasesink didn't use it
-   */
-  void (*set_property) (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
-
-
-  /*
-   * gstreamer wants to read a named property and rosbasesink doesn't have it
-   */
-  void (*get_property) (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
-
-
-  // stick member function pointers here
-  // along with member function pointers for signal handlers
 };
 
 GType rosbasesink_get_type (void);

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -52,8 +52,7 @@ struct _RosBaseSink
   rclcpp::Clock::SharedPtr clock;
   rclcpp::Time stream_start;
   GstClockTimeDiff ros_clock_offset;
-
-  rclcpp::QoS qos_override; //passed in to adjust pub qos
+  std::thread spin_thread;
 
 };
 

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -1,0 +1,124 @@
+/* GStreamer
+ * Copyright (C) 2020 FIXME <fixme@example.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _GST_ROS_BASE_SINK_H_
+#define _GST_ROS_BASE_SINK_H_
+
+#include <gst/base/gstbasesink.h>
+#include <gst_bridge/gst_bridge.h>
+
+//include ROS and ROS message formats
+#include <rclcpp/rclcpp.hpp>
+
+
+G_BEGIN_DECLS
+//XXX need to declare as virtual / subclassable
+#define GST_TYPE_ROS_BASE_SINK   (rosbasesink_get_type())
+#define GST_ROS_BASE_SINK(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_ROS_BASE_SINK,RosBaseSink))
+#define GST_ROS_BASE_SINK_CAST(obj)        ((RosBaseSink*)obj)
+#define GST_ROS_BASE_SINK_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_ROS_BASE_SINK,RosBaseSinkClass))
+#define GST_ROS_BASE_SINK_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_ROS_BASE_SINK, RosBaseSinkClass))
+#define GST_IS_ROS_BASE_SINK(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_ROS_BASE_SINK))
+#define GST_IS_ROS_BASE_SINK_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_ROS_BASE_SINK))
+
+typedef struct _RosBaseSink RosBaseSink;
+typedef struct _RosBaseSinkClass RosBaseSinkClass;
+
+struct _RosBaseSink
+{
+  GstBaseSink parent;
+  gchar* node_name;
+  gchar* node_namespace;
+  gchar* pub_topic;
+
+  rclcpp::Context::SharedPtr ros_context;
+  rclcpp::executor::Executor::SharedPtr ros_executor;
+  rclcpp::Node::SharedPtr node;
+  rclcpp::Logger logger;
+  rclcpp::Clock::SharedPtr clock;
+  GstClockTimeDiff ros_clock_offset;
+
+  gchar* init_caps; //a hack to allow skipping preroll
+  rclcpp::QoS qos_override; //passed in to adjust pub qos
+
+};
+
+struct _RosBaseSinkClass
+{
+  GstBaseSinkClass parent_class;
+
+
+  /*
+   * called shortly after the node is created
+   * register publishers with ROS (context, node, clock, and logger are handled for you)
+   * called at gstbasesink->change_state()  GST_STATE_CHANGE_NULL_TO_READY
+   * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
+   */
+  static gboolean (*open) (RosBaseSink * sink, gchar* pub_topic, rclcpp::QoS qos_override);
+
+
+  /*
+   * destroy the ros publisher(s) and unregister your callbacks and timers and prepare for ros_context->shutdown()
+   * called at gstbasesink->change_state()  GST_STATE_CHANGE_READY_TO_NULL
+   * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
+   */
+  void (*close) (RosBaseSink * sink);
+
+
+  /*
+   * this is a step in caps negitation, send a pull request on this comment if you know what this really does
+   */
+  static gboolean (*setcaps) (RosBaseSink * sink, GstCaps * caps)
+
+
+  /*
+   * this is a step in caps negitation, send a pull request on this comment if you know what this really does
+   */
+  static GstCaps * (*fixate) (RosBaseSink * sink, GstCaps * caps)
+
+
+  /*
+   * publish the message
+   * msg_time is derived from buf and offset by rostime at pipeline playtime
+   * rosbasesink will calculate msg_time, you can bypass that by using gstbasesink's render() instead
+   */
+  static GstFlowReturn (*render) (RosBaseSink * base_sink, GstBuffer * buf, rclcpp::Time msg_time);
+
+
+  /*
+   * gstreamer wants to set a named property and rosbasesink didn't use it
+   */
+  void (*set_property) (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec)
+
+
+  /*
+   * gstreamer wants to read a named property and rosbasesink doesn't have it
+   */
+  static void (*get_property) (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
+
+
+  // stick member function pointers here
+  // along with member function pointers for signal handlers
+};
+
+GType rosbasesink_get_type (void);
+
+G_END_DECLS
+
+#endif

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2020 FIXME <fixme@example.com>
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -83,14 +83,14 @@ struct _RosBaseSinkClass
    * gstreamer tells us what caps we should set up to deal with
    * this may be called several times, including during playback?
    */
-  gboolean (*set_caps) (RosBaseSink * sink, GstCaps * caps)
+  gboolean (*set_caps) (RosBaseSink * sink, GstCaps * caps);
 
 
   /*
    * gstreamer asks us for a caps filter for downstream to choose out of
    *
    */
-  GstCaps*  (*get_caps) (GstBaseSink *sink, GstCaps *filter);
+  GstCaps*  (*get_caps) (RosBaseSink *sink, GstCaps *filter);
 
 
   /*
@@ -98,19 +98,19 @@ struct _RosBaseSinkClass
    * msg_time is derived from buf and offset by rostime at pipeline playtime
    * rosbasesink will calculate msg_time, you can bypass that by using gstbasesink's render() instead
    */
-  static GstFlowReturn (*render) (RosBaseSink * base_sink, GstBuffer * buf, rclcpp::Time msg_time);
+  GstFlowReturn (*render) (RosBaseSink * base_sink, GstBuffer * buf, rclcpp::Time msg_time);
 
 
   /*
    * gstreamer wants to set a named property and rosbasesink didn't use it
    */
-  void (*set_property) (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec)
+  void (*set_property) (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
 
 
   /*
    * gstreamer wants to read a named property and rosbasesink doesn't have it
    */
-  static void (*get_property) (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
+  void (*get_property) (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
 
 
   // stick member function pointers here

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -45,7 +45,6 @@ struct _RosBaseSink
   GstBaseSink parent;
   gchar* node_name;
   gchar* node_namespace;
-  gchar* pub_topic;
 
   rclcpp::Context::SharedPtr ros_context;
   rclcpp::executor::Executor::SharedPtr ros_executor;
@@ -54,7 +53,6 @@ struct _RosBaseSink
   rclcpp::Clock::SharedPtr clock;
   GstClockTimeDiff ros_clock_offset;
 
-  gchar* init_caps; //a hack to allow skipping preroll
   rclcpp::QoS qos_override; //passed in to adjust pub qos
 
 };
@@ -70,7 +68,7 @@ struct _RosBaseSinkClass
    * called at gstbasesink->change_state()  GST_STATE_CHANGE_NULL_TO_READY
    * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
    */
-  static gboolean (*open) (RosBaseSink * sink, gchar* pub_topic, rclcpp::QoS qos_override);
+  gboolean (*open) (RosBaseSink * sink);
 
 
   /*
@@ -78,19 +76,21 @@ struct _RosBaseSinkClass
    * called at gstbasesink->change_state()  GST_STATE_CHANGE_READY_TO_NULL
    * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
    */
-  void (*close) (RosBaseSink * sink);
+  gboolean (*close) (RosBaseSink * sink);
 
 
   /*
-   * this is a step in caps negitation, send a pull request on this comment if you know what this really does
+   * gstreamer tells us what caps we should set up to deal with
+   * this may be called several times, including during playback?
    */
-  static gboolean (*setcaps) (RosBaseSink * sink, GstCaps * caps)
+  gboolean (*set_caps) (RosBaseSink * sink, GstCaps * caps)
 
 
   /*
-   * this is a step in caps negitation, send a pull request on this comment if you know what this really does
+   * gstreamer asks us for a caps filter for downstream to choose out of
+   *
    */
-  static GstCaps * (*fixate) (RosBaseSink * sink, GstCaps * caps)
+  GstCaps*  (*get_caps) (GstBaseSink *sink, GstCaps *filter);
 
 
   /*

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -90,7 +90,14 @@ struct _RosBaseSinkClass
    * gstreamer asks us for a caps filter for downstream to choose out of
    *
    */
-  GstCaps*  (*get_caps) (RosBaseSink *sink, GstCaps *filter);
+  GstCaps*  (*get_caps) (RosBaseSink * sink, GstCaps * filter);
+
+
+  /*
+   * gstreamer asks us for a caps filter for downstream to choose out of
+   *
+   */
+  gboolean (*query) (RosBaseSink * sink, GstQuery * query);
 
 
   /*

--- a/gst_bridge/include/gst_bridge/rosbasesrc.h
+++ b/gst_bridge/include/gst_bridge/rosbasesrc.h
@@ -51,6 +51,7 @@ struct _RosBaseSrc
   rclcpp::Logger logger;
   rclcpp::Clock::SharedPtr clock;
   rclcpp::Time stream_start;
+  std::thread spin_thread;
   GstClockTimeDiff ros_clock_offset;
 
 };

--- a/gst_bridge/include/gst_bridge/rosbasesrc.h
+++ b/gst_bridge/include/gst_bridge/rosbasesrc.h
@@ -1,0 +1,85 @@
+/* GStreamer
+ * Copyright (C) 2020 FIXME <fixme@example.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _GST_ROS_BASE_SRC_H_
+#define _GST_ROS_BASE_SRC_H_
+
+#include <gst/base/gstbasesrc.h>
+#include <gst_bridge/gst_bridge.h>
+
+//include ROS and ROS message formats
+#include <rclcpp/rclcpp.hpp>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_ROS_BASE_SRC   (rosbasesrc_get_type())
+#define GST_ROS_BASE_SRC(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_ROS_BASE_SRC,RosBaseSrc))
+#define GST_ROS_BASE_SRC_CAST(obj)        ((RosBaseSrc*)obj)
+#define GST_ROS_BASE_SRC_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_ROS_BASE_SRC,RosBaseSrcClass))
+#define GST_ROS_BASE_SRC_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_ROS_BASE_SRC, RosBaseSrcClass))
+#define GST_IS_ROS_BASE_SRC(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_ROS_BASE_SRC))
+#define GST_IS_ROS_BASE_SRC_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_ROS_BASE_SRC))
+
+typedef struct _RosBaseSrc RosBaseSrc;
+typedef struct _RosBaseSrcClass RosBaseSrcClass;
+
+struct _RosBaseSrc
+{
+  GstBaseSrc parent;
+  gchar* node_name;
+  gchar* node_namespace;
+
+  rclcpp::Context::SharedPtr ros_context;
+  rclcpp::executor::Executor::SharedPtr ros_executor;
+  rclcpp::Node::SharedPtr node;
+  rclcpp::Logger logger;
+  rclcpp::Clock::SharedPtr clock;
+  rclcpp::Time stream_start;
+  GstClockTimeDiff ros_clock_offset;
+
+};
+
+struct _RosBaseSrcClass
+{
+  GstBaseSrcClass parent_class;
+
+
+  /*
+   * called shortly after the node is created
+   * register subscription with ROS (context, node, clock, and logger are handled for you)
+   * called at gstbasesrc->change_state()  GST_STATE_CHANGE_NULL_TO_READY
+   * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
+   */
+  gboolean (*open) (RosBaseSrc * src);
+
+
+  /*
+   * destroy the ros subscription(s) and unregister your callbacks and timers and prepare for ros_context->shutdown()
+   * called at gstbasesrc->change_state()  GST_STATE_CHANGE_READY_TO_NULL
+   * timers and reconf callbacks are currently broken, needs a new thread with an executor, patches welcome
+   */
+  gboolean (*close) (RosBaseSrc * src);
+
+};
+
+GType rosbasesrc_get_type (void);
+
+G_END_DECLS
+
+#endif

--- a/gst_bridge/include/gst_bridge/rosimagesink.h
+++ b/gst_bridge/include/gst_bridge/rosimagesink.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2020 FIXME <fixme@example.com>
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -23,6 +23,7 @@
 #include <gst/video/video-format.h>
 #include <gst/base/gstbasesink.h>
 #include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesink.h>
 
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
@@ -42,20 +43,14 @@ typedef struct _RosimagesinkClass RosimagesinkClass;
 
 struct _Rosimagesink
 {
-  GstBaseSink parent;
-  gchar* node_name;
-  gchar* node_namespace;
+  RosBaseSink parent;
+
   gchar* pub_topic;
   gchar* frame_id;
   gchar* encoding; //image topic encoding string
   gchar* init_caps; //optional caps override (used for limited apis)
 
-  rclcpp::Context::SharedPtr ros_context;
-  rclcpp::Node::SharedPtr node;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub;
-  rclcpp::Logger logger;
-  rclcpp::Clock::SharedPtr clock;
-  GstClockTimeDiff ros_clock_offset;
 
   int height;
   int width;
@@ -66,7 +61,7 @@ struct _Rosimagesink
 
 struct _RosimagesinkClass
 {
-  GstBaseSinkClass parent_class;
+  RosBaseSinkClass parent_class;
 
   // stick member function pointers here
   // along with member function pointers for signal handlers

--- a/gst_bridge/include/gst_bridge/rosimagesrc.h
+++ b/gst_bridge/include/gst_bridge/rosimagesrc.h
@@ -28,6 +28,9 @@
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <queue>  // std::queue
+#include <mutex>  // std::mutex, std::unique_lock
+#include <condition_variable> // std::condition_variable
 
 G_BEGIN_DECLS
 
@@ -51,7 +54,12 @@ struct _Rosimagesrc
   gchar* init_caps;
 
   bool msg_init;
-  std::promise<sensor_msgs::msg::Image::ConstSharedPtr> new_msg;
+
+  // XXX this is too much boilerplate.
+  size_t msg_queue_max;
+  std::queue<sensor_msgs::msg::Image::ConstSharedPtr> msg_queue;
+  std::mutex msg_queue_mtx;
+  std::condition_variable msg_queue_cv;
 
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub;
   

--- a/gst_bridge/include/gst_bridge/rosimagesrc.h
+++ b/gst_bridge/include/gst_bridge/rosimagesrc.h
@@ -23,17 +23,19 @@
 #include <gst/video/video-format.h>
 #include <gst/base/gstbasesrc.h>
 #include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesrc.h>
 
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
-
 G_BEGIN_DECLS
 
 #define GST_TYPE_ROSIMAGESRC   (rosimagesrc_get_type())
 #define GST_ROSIMAGESRC(obj)   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_ROSIMAGESRC,Rosimagesrc))
+#define GST_ROSIMAGESRC_CAST(obj)        ((Rosimagesrc*)obj)
 #define GST_ROSIMAGESRC_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_ROSIMAGESRC,RosimagesrcClass))
+#define GST_ROSIMAGESRC_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_ROSIMAGESRC, RosimagesrcClass))
 #define GST_IS_ROSIMAGESRC(obj)   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_ROSIMAGESRC))
 #define GST_IS_ROSIMAGESRC_CLASS(obj)   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_ROSIMAGESRC))
 
@@ -42,9 +44,7 @@ typedef struct _RosimagesrcClass RosimagesrcClass;
 
 struct _Rosimagesrc
 {
-  GstBaseSrc parent;
-  gchar* node_name;
-  gchar* node_namespace;
+  RosBaseSrc parent;
   gchar* sub_topic;
   gchar* frame_id;
   gchar* encoding;
@@ -53,14 +53,8 @@ struct _Rosimagesrc
   bool msg_init;
   std::promise<sensor_msgs::msg::Image::ConstSharedPtr> new_msg;
 
-  rclcpp::Context::SharedPtr ros_context;
-  rclcpp::executor::Executor::SharedPtr ros_executor;
-  rclcpp::Node::SharedPtr node;
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub;
-  rclcpp::Logger logger;
-  rclcpp::Clock::SharedPtr clock;
-  GstClockTimeDiff ros_clock_offset;
-
+  
   int height;
   int width;
   GstVideoFormat format;
@@ -70,7 +64,7 @@ struct _Rosimagesrc
 
 struct _RosimagesrcClass
 {
-  GstBaseSrcClass parent_class;
+  RosBaseSrcClass parent_class;
 
   // stick member function pointers here
   // along with member function pointers for signal handlers

--- a/gst_bridge/package.xml
+++ b/gst_bridge/package.xml
@@ -10,14 +10,16 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
 
-  <build_depend>std_msgs</build_depend>
-  <build_depend>libgst-dev</build_depend>
-  <build_depend>audio_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>libgst-dev</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>audio_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>audio_msgs</exec_depend>
-  
+  <exec_depend>sensor_msgs</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/gst_bridge/src/gst_bridge.cpp
+++ b/gst_bridge/src/gst_bridge.cpp
@@ -3,10 +3,10 @@
 namespace gst_bridge
 {
 
-GstClockTimeDiff sample_clock_offset(GstClock* gst_clock, rclcpp::Clock::SharedPtr ros_clock)
+GstClockTimeDiff sample_clock_offset(GstClock* gst_clock, rclcpp::Time stream_start)
 {
   GstClockTime g_time = gst_clock_get_time (gst_clock); //gst time now
-  GstClockTime r_time = ros_clock->now().nanoseconds();  //ros time now
+  GstClockTime r_time = stream_start.nanoseconds();  //ros time now
   return r_time - g_time;  //instantaneous offset between ros and gst
 }
 

--- a/gst_bridge/src/rosaudiosink.cpp
+++ b/gst_bridge/src/rosaudiosink.cpp
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2020 FIXME <fixme@example.com>
+ * Copyright (C) 2020 BrettRD <brettrd@brettrd.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -42,20 +42,15 @@ GST_DEBUG_CATEGORY_STATIC (rosaudiosink_debug_category);
 
 static void rosaudiosink_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
 static void rosaudiosink_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
-static void rosaudiosink_dispose (GObject * object);  //unused?
-static void rosaudiosink_finalize (GObject * object);
 
-
-static GstStateChangeReturn rosaudiosink_change_state (GstElement * element, GstStateChange transition);
 static void rosaudiosink_init (Rosaudiosink * rosaudiosink);
-static GstCaps * rosaudiosink_fixate (GstBaseSink * bsink, GstCaps * caps);
 
+static gboolean rosaudiosink_open (RosBaseSink * sink);
+static gboolean rosaudiosink_close (RosBaseSink * sink);
 static gboolean rosaudiosink_setcaps (GstBaseSink * sink, GstCaps * caps);
-static GstFlowReturn rosaudiosink_render (GstBaseSink * sink, GstBuffer * buffer);
+static GstCaps* rosaudiosink_getcaps (GstBaseSink * sink, GstCaps * filter);
 
-
-static gboolean rosaudiosink_open (Rosaudiosink * sink);
-static gboolean rosaudiosink_close (Rosaudiosink * sink);
+static GstFlowReturn rosaudiosink_render (GstBaseSink * sink, GstBuffer * buffer, rclcpp::Time msg_time);
 
 /*
   XXX provide a mechanism for ROS to provide a clock
@@ -65,8 +60,6 @@ static gboolean rosaudiosink_close (Rosaudiosink * sink);
 enum
 {
   PROP_0,
-  PROP_ROS_NAME,
-  PROP_ROS_NAMESPACE,
   PROP_ROS_TOPIC,
   PROP_ROS_FRAME_ID,
   PROP_ROS_ENCODING,
@@ -97,8 +90,6 @@ static void rosaudiosink_class_init (RosaudiosinkClass * klass)
 
   object_class->set_property = rosaudiosink_set_property;
   object_class->get_property = rosaudiosink_get_property;
-  object_class->dispose = rosaudiosink_dispose;
-  object_class->finalize = rosaudiosink_finalize;
 
 
   /* Setting up pads and setting metadata should be moved to
@@ -110,20 +101,8 @@ static void rosaudiosink_class_init (RosaudiosinkClass * klass)
   gst_element_class_set_static_metadata (element_class,
       "rosaudiosink",
       "Sink",
-      "a gstreamer sink that publishes audiodata into ROS",
+      "a gstreamer sink that publishes audio data into ROS",
       "BrettRD <brettrd@brettrd.com>");
-
-  g_object_class_install_property (object_class, PROP_ROS_NAME,
-      g_param_spec_string ("ros-name", "node-name", "Name of the ROS node",
-      "gst_audio_sink_node",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
-
-  g_object_class_install_property (object_class, PROP_ROS_NAMESPACE,
-      g_param_spec_string ("ros-namespace", "node-namespace", "Namespace for the ROS node",
-      "",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
 
   g_object_class_install_property (object_class, PROP_ROS_TOPIC,
       g_param_spec_string ("ros-topic", "pub-topic", "ROS topic to be published on",
@@ -167,8 +146,8 @@ static void rosaudiosink_init (Rosaudiosink * sink)
   // Don't register the node or the publisher just yet,
   // wait for rosaudiosink_open()
   // XXX set defaults elsewhere to keep gst-inspect consistent
-  sink->node_name = g_strdup("gst_audio_sink_node");
-  sink->node_namespace = g_strdup("");
+  //sink->node_name = g_strdup("gst_audio_sink_node");  //XXX overwrite the node name, but don't take over the property
+  //sink->node_namespace = g_strdup("");
   sink->pub_topic = g_strdup("gst_audio_pub");
   sink->frame_id = g_strdup("audio_frame");
   sink->encoding = g_strdup("16SC1");
@@ -183,34 +162,11 @@ void rosaudiosink_set_property (GObject * object, guint property_id,
   GST_DEBUG_OBJECT (sink, "set_property");
 
   switch (property_id) {
-    case PROP_ROS_NAME:
-      if(sink->node)
-      {
-        RCLCPP_ERROR(sink->logger, "can't change node name once openned");
-      }
-      else
-      {
-        g_free(sink->node_name);
-        sink->node_name = g_value_dup_string(value);
-      }
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      if(sink->node)
-      {
-        RCLCPP_ERROR(sink->logger, "can't change node namespace once openned");
-      }
-      else
-      {
-        g_free(sink->node_namespace);
-        sink->node_namespace = g_value_dup_string(value);
-      }
-      break;
-
     case PROP_ROS_TOPIC:
       if(sink->node)
       {
         RCLCPP_ERROR(sink->logger, "can't change topic name once openned");
+        // XXX try harder
       }
       else
       {
@@ -256,14 +212,6 @@ void rosaudiosink_get_property (GObject * object, guint property_id,
 
   GST_DEBUG_OBJECT (sink, "get_property");
   switch (property_id) {
-    case PROP_ROS_NAME:
-      g_value_set_string(value, sink->node_name);
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      g_value_set_string(value, sink->node_namespace);
-      break;
-
     case PROP_ROS_TOPIC:
       g_value_set_string(value, sink->pub_topic);
       break;
@@ -286,105 +234,34 @@ void rosaudiosink_get_property (GObject * object, guint property_id,
   }
 }
 
-void rosaudiosink_dispose (GObject * object)
-{
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (object);
-
-  GST_DEBUG_OBJECT (sink, "dispose");
-
-  /* clean up as possible.  may be called multiple times */
-
-  G_OBJECT_CLASS (rosaudiosink_parent_class)->dispose (object);
-}
-
-void rosaudiosink_finalize (GObject * object)
-{
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (object);
-
-  GST_DEBUG_OBJECT (sink, "finalize");
-
-  /* clean up object here */
-
-  G_OBJECT_CLASS (rosaudiosink_parent_class)->finalize (object);
-}
-
-
-static GstStateChangeReturn rosaudiosink_change_state (GstElement * element, GstStateChange transition)
-{
-  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (element);
-
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_NULL_TO_READY:
-    {
-      //gst_audio_clock_reset (GST_AUDIO_CLOCK (sink->provided_clock), 0);
-      if (!rosaudiosink_open(sink))
-      {
-        GST_DEBUG_OBJECT (sink, "open failed");
-        return GST_STATE_CHANGE_FAILURE;
-      }
-      break;
-    }
-    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-    {
-      sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->clock);
-      sink->msg_seq_num = 0;
-      break;
-    }
-    case GST_STATE_CHANGE_READY_TO_PAUSED:
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  ret = GST_ELEMENT_CLASS (rosaudiosink_parent_class)->change_state (element, transition);
-
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_READY_TO_NULL:
-      rosaudiosink_close(sink);
-      break;
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  return ret;
-
-}
 
 /* open the device with given specs */
-static gboolean rosaudiosink_open (Rosaudiosink * sink)
+static gboolean rosaudiosink_open (RosBaseSink * ros_base_sink)
 {
   GST_DEBUG_OBJECT (sink, "open");
+  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
 
-  sink->ros_context = std::make_shared<rclcpp::Context>();
-  sink->ros_context->init(0, NULL);    // XXX should expose the init arg list
-  rclcpp::NodeOptions opts = rclcpp::NodeOptions();
-  opts.context(sink->ros_context); //set a context to generate the node in
-  sink->node = std::make_shared<rclcpp::Node>(std::string(sink->node_name), std::string(sink->node_namespace), opts);
   rclcpp::QoS qos = rclcpp::SensorDataQoS().reliable();  //XXX add a parameter for overrides
-  sink->pub = sink->node->create_publisher<audio_msgs::msg::Audio>(sink->pub_topic, qos);
-  sink->logger = sink->node->get_logger();
-  sink->clock = sink->node->get_clock();
+  sink->pub = ros_base_sink->node->create_publisher<audio_msgs::msg::Audio>(sink->pub_topic, qos);
+
   return TRUE;
 }
 
 /* close the device */
-static gboolean rosaudiosink_close (Rosaudiosink * sink)
+static gboolean rosaudiosink_close (RosBaseSink * ros_base_sink)
 {
   GST_DEBUG_OBJECT (sink, "close");
+  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
 
-  sink->clock.reset();
   sink->pub.reset();
-  sink->node.reset();
-  sink->ros_context->shutdown("gst closing rosaudiosink");
+
   return TRUE;
 }
 
+
+/*
+// XXX fixate is only used for pull mode which this sink can't do.
+//       some of this logic needs to move to get_caps
 static GstCaps * rosaudiosink_fixate (GstBaseSink * base_sink, GstCaps * caps)
 {
   //XXX check init_caps and fixate to that
@@ -398,15 +275,15 @@ static GstCaps * rosaudiosink_fixate (GstBaseSink * base_sink, GstCaps * caps)
 
   s = gst_caps_get_structure (caps, 0);
 
-  /* fields for all formats */
+  // fields for all formats
   gst_structure_fixate_field_nearest_int (s, "rate", 44100);
   gst_structure_fixate_field_nearest_int (s, "channels", 2);
   gst_structure_fixate_field_nearest_int (s, "width", 16);
 
-  /* fields for int */
+  // fields for int
   if (gst_structure_has_field (s, "depth")) {
     gst_structure_get_int (s, "width", &width);
-    /* round width to nearest multiple of 8 for the depth */
+    // round width to nearest multiple of 8 for the depth
     depth = GST_ROUND_UP_8 (width);
     gst_structure_fixate_field_nearest_int (s, "depth", depth);
   }
@@ -419,14 +296,14 @@ static GstCaps * rosaudiosink_fixate (GstBaseSink * base_sink, GstCaps * caps)
 
   return caps;
 }
+*/
 
-
-/* check the caps, register a node and open an publisher */
-static gboolean rosaudiosink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
+// gstreamer is changing the caps, try to keep up
+static gboolean rosaudiosink_setcaps (RosBaseSink * ros_base_sink, GstCaps * caps)
 {
   GstAudioInfo audio_info;
 
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (base_sink);
+  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
 
   GST_DEBUG_OBJECT (sink, "setcaps");
 
@@ -446,28 +323,30 @@ static gboolean rosaudiosink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
     return true;
   }
 
-  return false;
+  return false; // XXX why simply reject? ros2 messages are flexible
+}
+
+static GstCaps* rosaudiosink_getcaps (RosBaseSink * ros_base_sink, GstCaps * filter)
+{
+  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
+
+  // XXX narrow down the filter using logic from the old fixate
+
+  return filter;
 }
 
 
-
-static GstFlowReturn rosaudiosink_render (GstBaseSink * base_sink, GstBuffer * buf)
+static GstFlowReturn rosaudiosink_render (RosBaseSink * ros_base_sink, GstBuffer * buf, rclcpp::Time msg_time)
 {
   GstMapInfo info;
-  rclcpp::Time msg_time;
-  GstClockTimeDiff base_time;
   audio_msgs::msg::Audio msg;
 
-  // XXX look into borrowed messages, can buf be extended into the middleware?
+  // XXX use borrowed messages, can buf be extended into the middleware?
   //    auto msg = sink->pub->borrow_loaned_message();
   //    msg.get().frames = ...
 
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (base_sink);
+  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
   GST_DEBUG_OBJECT (sink, "render");
-
-  // XXX use the base sink clock synchronising features
-  base_time = gst_element_get_base_time(GST_ELEMENT(sink));
-  msg_time = rclcpp::Time(GST_BUFFER_PTS(buf) + base_time + sink->ros_clock_offset, sink->clock->get_clock_type());
 
   msg = gst_bridge::gst_audio_info_to_audio_msg(&(sink->audio_info));
   msg.header.stamp = msg_time;

--- a/gst_bridge/src/rosaudiosink.cpp
+++ b/gst_bridge/src/rosaudiosink.cpp
@@ -43,16 +43,13 @@ GST_DEBUG_CATEGORY_STATIC (rosaudiosink_debug_category);
 static void rosaudiosink_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
 static void rosaudiosink_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
 
-static void rosaudiosink_init (Rosaudiosink * rosaudiosink);
+static void rosaudiosink_init (Rosaudiosink * sink);
 
-static gboolean rosaudiosink_open (RosBaseSink * sink);
-static gboolean rosaudiosink_close (RosBaseSink * sink);
-static GstCaps* rosaudiosink_getcaps (RosBaseSink * sink, GstCaps * filter);
-static gboolean rosaudiosink_setcaps (RosBaseSink * sink, GstCaps * caps);
-static gboolean rosaudiosink_query (RosBaseSink * sink, GstQuery * query);
+static gboolean rosaudiosink_open (RosBaseSink * ros_base_sink);
+static gboolean rosaudiosink_close (RosBaseSink * ros_base_sink);
+static gboolean rosaudiosink_setcaps (GstBaseSink * gst_base_sink, GstCaps * caps);
 
 static GstFlowReturn rosaudiosink_render (RosBaseSink * sink, GstBuffer * buffer, rclcpp::Time msg_time);
-//XXX pretty sure query is required
 
 enum
 {
@@ -60,7 +57,6 @@ enum
   PROP_ROS_TOPIC,
   PROP_ROS_FRAME_ID,
   PROP_ROS_ENCODING,
-  PROP_INIT_CAPS,
 };
 
 
@@ -83,7 +79,7 @@ static void rosaudiosink_class_init (RosaudiosinkClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
-  //GstBaseSinkClass *basesink_class = GST_BASE_SINK_CLASS (klass);  //unused
+  GstBaseSinkClass *basesink_class = GST_BASE_SINK_CLASS (klass);  //unused
   RosBaseSinkClass *ros_base_sink_class = GST_ROS_BASE_SINK_CLASS (klass);
 
   object_class->set_property = rosaudiosink_set_property;
@@ -120,18 +116,10 @@ static void rosaudiosink_class_init (RosaudiosinkClass * klass)
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
 
-  g_object_class_install_property (object_class, PROP_INIT_CAPS,
-      g_param_spec_string ("init-caps", "initial-caps", "optional caps filter to skip wait for first message",
-      "",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
-
-  //basesink_class->  //access gstreamer base sink events here
+  //access gstreamer base sink events here
+  basesink_class->set_caps = GST_DEBUG_FUNCPTR (rosaudiosink_setcaps);  //gstreamer informs us what caps we're using.
 
   //supply the calls ros base sink needs to negotiate upstream formats and manage the publisher
-  ros_base_sink_class->set_caps = GST_DEBUG_FUNCPTR (rosaudiosink_setcaps);  //gstreamer informs us what caps we're using.
-  ros_base_sink_class->get_caps = GST_DEBUG_FUNCPTR (rosaudiosink_getcaps);  //gstreamer asks what caps we can deal with
-  ros_base_sink_class->query = GST_DEBUG_FUNCPTR (rosaudiosink_query);  //gstreamer asks what caps we recommend
   ros_base_sink_class->open = GST_DEBUG_FUNCPTR (rosaudiosink_open);  //let the base sink know how we register publishers
   ros_base_sink_class->close = GST_DEBUG_FUNCPTR (rosaudiosink_close);  //let the base sink know how we destroy publishers
   ros_base_sink_class->render = GST_DEBUG_FUNCPTR (rosaudiosink_render); // gives us a buffer to package
@@ -144,7 +132,6 @@ static void rosaudiosink_init (Rosaudiosink * sink)
   sink->pub_topic = g_strdup("gst_audio_pub");
   sink->frame_id = g_strdup("audio_frame");
   sink->encoding = g_strdup("16SC1");
-  sink->init_caps =  g_strdup("");
 }
 
 void rosaudiosink_set_property (GObject * object, guint property_id,
@@ -179,19 +166,6 @@ void rosaudiosink_set_property (GObject * object, guint property_id,
       sink->encoding = g_value_dup_string(value);
       break;
 
-    case PROP_INIT_CAPS:
-      if(ros_base_sink->node)  // XXX wrong condition, but close enough
-      {
-        RCLCPP_ERROR(ros_base_sink->logger, "can't change initial caps after init");
-      }
-      else
-      {
-        g_free(sink->init_caps);
-        sink->init_caps = g_value_dup_string(value);
-        // XXX set up the image message checks and unpack the caps
-      }
-      break;
-
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -215,10 +189,6 @@ void rosaudiosink_get_property (GObject * object, guint property_id,
 
     case PROP_ROS_ENCODING:
       g_value_set_string(value, sink->encoding);
-      break;
-
-    case PROP_INIT_CAPS:
-      g_value_set_string(value, sink->init_caps);
       break;
 
     default:
@@ -252,11 +222,12 @@ static gboolean rosaudiosink_close (RosBaseSink * ros_base_sink)
 
 
 // gstreamer is changing the caps, try to adapt to it
-static gboolean rosaudiosink_setcaps (RosBaseSink * ros_base_sink, GstCaps * caps)
+static gboolean rosaudiosink_setcaps (GstBaseSink * gst_base_sink, GstCaps * caps)
 {
-  GstAudioInfo audio_info;
-
+  RosBaseSink *ros_base_sink = GST_ROS_BASE_SINK (gst_base_sink);
   Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
+
+  GstAudioInfo audio_info;
 
   GST_DEBUG_OBJECT (sink, "setcaps");
 
@@ -278,28 +249,6 @@ static gboolean rosaudiosink_setcaps (RosBaseSink * ros_base_sink, GstCaps * cap
 
   return false;
 }
-
-
-static GstCaps* rosaudiosink_getcaps (RosBaseSink * ros_base_sink, GstCaps * filter)
-{
-  Rosaudiosink *sink = GST_ROSAUDIOSINK (ros_base_sink);
-
-  //this is called several times during caps negotiation to decide on a pipeline format
-  // if we return NULL, the base sink will simply fetch our template caps and offer that selection to the src.
-
-  //XXX this is extremely fragile, and only works for very narrow parameters where caps negotiation is short-cut
-  //XXX look at alsasink, there's an intersection function in there to narrow down on what's possible
-
-  return filter;
-}
-
-static gboolean rosaudiosink_query (RosBaseSink * sink, GstQuery * query)
-{
-
-  return FALSE;
-}
-
-
 
 
 static GstFlowReturn rosaudiosink_render (RosBaseSink * ros_base_sink, GstBuffer * buf, rclcpp::Time msg_time)

--- a/gst_bridge/src/rosaudiosrc.cpp
+++ b/gst_bridge/src/rosaudiosrc.cpp
@@ -314,6 +314,12 @@ static gboolean rosaudiosrc_close (RosBaseSrc * ros_base_src)
   GST_DEBUG_OBJECT (src, "close");
 
   src->sub.reset();
+  std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
+  while(src->msg_queue.size() > 0)
+  {
+    src->msg_queue.pop();
+  }
+
   return TRUE;
 }
 

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -1,0 +1,454 @@
+/* GStreamer
+ * Copyright (C) 2020 BrettRD <brettrd@brettrd.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Suite 500,
+ * Boston, MA 02110-1335, USA.
+ */
+/**
+ * SECTION:element-gstrosbasesink
+ *
+ * The rosbasesink element, pipe audio data into ROS2.
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * gst-launch-1.0 -v audiotestsrc ! rosbasesink node_name="gst_audio" topic="/audiotopic"
+ * ]|
+ * Streams test tones as ROS audio messages on topic.
+ * </refsect2>
+ */
+
+
+#include <gst_bridge/rosbasesink.h>
+
+
+GST_DEBUG_CATEGORY_STATIC (rosbasesink_debug_category);
+#define GST_CAT_DEFAULT rosbasesink_debug_category
+
+/* prototypes */
+
+
+static void rosbasesink_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
+static void rosbasesink_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
+static void rosbasesink_dispose (GObject * object);  //unused?
+static void rosbasesink_finalize (GObject * object);
+
+
+static GstStateChangeReturn rosbasesink_change_state (GstElement * element, GstStateChange transition);
+static void rosbasesink_init (RosBaseSink * rosbasesink);
+static GstCaps * rosbasesink_fixate (GstBaseSink * bsink, GstCaps * caps);
+
+static gboolean rosbasesink_setcaps (GstBaseSink * sink, GstCaps * caps);
+static GstFlowReturn rosbasesink_render (GstBaseSink * sink, GstBuffer * buffer);
+
+
+static gboolean rosbasesink_open (RosBaseSink * sink);
+static gboolean rosbasesink_close (RosBaseSink * sink);
+
+/*
+  XXX provide a mechanism for ROS to provide a clock
+*/
+
+
+enum
+{
+  PROP_0,
+  PROP_ROS_NAME,
+  PROP_ROS_NAMESPACE,
+  PROP_ROS_TOPIC,
+  PROP_ROS_FRAME_ID,
+  PROP_ROS_ENCODING,
+  PROP_INIT_CAPS,
+};
+
+
+/* pad templates */
+
+static GstStaticPadTemplate rosbasesink_sink_template =
+GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (ROS_AUDIO_MSG_CAPS)
+    );
+
+/* class initialization */
+
+G_DEFINE_TYPE_WITH_CODE (RosBaseSink, rosbasesink, GST_TYPE_BASE_SINK,
+    GST_DEBUG_CATEGORY_INIT (rosbasesink_debug_category, "rosbasesink", 0,
+        "debug category for rosbasesink element"))
+
+static void rosbasesink_class_init (RosBaseSinkClass * klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSinkClass *basesink_class = (GstBaseSinkClass *) klass;
+
+  object_class->set_property = rosbasesink_set_property;
+  object_class->get_property = rosbasesink_get_property;
+  object_class->dispose = rosbasesink_dispose;
+  object_class->finalize = rosbasesink_finalize;
+
+
+  /* Setting up pads and setting metadata should be moved to
+     base_class_init if you intend to subclass this class. */
+  gst_element_class_add_static_pad_template (element_class,
+      &rosbasesink_sink_template);
+
+
+  gst_element_class_set_static_metadata (element_class,
+      "rosbasesink",
+      "Sink",
+      "a gstreamer sink class for handling boilerplate ROS2 interactions",
+      "BrettRD <brettrd@brettrd.com>");
+
+  g_object_class_install_property (object_class, PROP_ROS_NAME,
+      g_param_spec_string ("ros-name", "node-name", "Name of the ROS node",
+      "gst_base_sink_node",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+  g_object_class_install_property (object_class, PROP_ROS_NAMESPACE,
+      g_param_spec_string ("ros-namespace", "node-namespace", "Namespace for the ROS node",
+      "",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+  g_object_class_install_property (object_class, PROP_ROS_TOPIC,
+      g_param_spec_string ("ros-topic", "pub-topic", "ROS topic to be published on",
+      "gst_base_pub",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+  g_object_class_install_property (object_class, PROP_INIT_CAPS,
+      g_param_spec_string ("init-caps", "initial-caps", "optional caps filter to skip wait for first message",
+      "",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+
+  element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesink_change_state); //use state change events to open and close publishers
+  basesink_class->fixate = GST_DEBUG_FUNCPTR (rosbasesink_fixate); //set caps fields to our preferred values (if possible)
+  basesink_class->set_caps = GST_DEBUG_FUNCPTR (rosbasesink_setcaps);  //gstreamer informs us what caps we're using.
+  //basesink_class->event = GST_DEBUG_FUNCPTR (rosbasesink_event);  //flush events can cause discontinuities (flags exist in buffers)
+  //basesink_class->wait_event = GST_DEBUG_FUNCPTR (rosbasesink_wait_event); //eos events, finish rendering the output then return
+  //basesink_class->get_times = GST_DEBUG_FUNCPTR (rosbasesink_get_times); //asks us for start and stop times (?)
+  //basesink_class->preroll = GST_DEBUG_FUNCPTR (rosbasesink_preroll); //hands us the first buffer
+  basesink_class->render = GST_DEBUG_FUNCPTR (rosbasesink_render); // gives us a buffer to forward
+  //basesink_class->activate_pull = GST_DEBUG_FUNCPTR (rosbasesink_activate_pull);  //lets the sink drive the pipeline scheduling (useful for synchronising a file into a rosbag playback)
+
+}
+
+static void rosbasesink_init (RosBaseSink * sink)
+{
+  // Don't register the node or the publisher just yet,
+  // wait for rosbasesink_open()
+  // XXX set defaults elsewhere to keep gst-inspect consistent
+  sink->node_name = g_strdup("gst_base_sink_node");
+  sink->node_namespace = g_strdup("");
+  sink->pub_topic = g_strdup("gst_base_pub");
+  sink->init_caps =  g_strdup("");
+}
+
+void rosbasesink_set_property (GObject * object, guint property_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  RosBaseSink *sink = GST_ROS_BASE_SINK (object);
+
+  GST_DEBUG_OBJECT (sink, "set_property");
+
+  switch (property_id) {
+    case PROP_ROS_NAME:
+      if(sink->node)
+      {
+        RCLCPP_ERROR(sink->logger, "can't change node name once openned");
+      }
+      else
+      {
+        g_free(sink->node_name);
+        sink->node_name = g_value_dup_string(value);
+      }
+      break;
+
+    case PROP_ROS_NAMESPACE:
+      if(sink->node)
+      {
+        RCLCPP_ERROR(sink->logger, "can't change node namespace once openned");
+      }
+      else
+      {
+        g_free(sink->node_namespace);
+        sink->node_namespace = g_value_dup_string(value);
+      }
+      break;
+
+    case PROP_ROS_TOPIC:
+      if(sink->node)
+      {
+        RCLCPP_ERROR(sink->logger, "can't change topic name once openned");
+      }
+      else
+      {
+        g_free(sink->pub_topic);
+        sink->pub_topic = g_value_dup_string(value);
+      }
+      break;
+
+    case PROP_ROS_FRAME_ID:
+      g_free(sink->frame_id);
+      sink->frame_id = g_value_dup_string(value);
+      break;
+
+    case PROP_ROS_ENCODING:
+      g_free(sink->encoding);
+      sink->encoding = g_value_dup_string(value);
+      break;
+
+    case PROP_INIT_CAPS:
+      if(sink->node)  // XXX wrong condition, but close enough
+      {
+        RCLCPP_ERROR(sink->logger, "can't change initial caps after init");
+      }
+      else
+      {
+        g_free(sink->init_caps);
+        sink->init_caps = g_value_dup_string(value);
+        // XXX set up the image message checks and unpack the caps
+        // XXX return the init_caps in fixate(), and probably earlier than that
+      }
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+void rosbasesink_get_property (GObject * object, guint property_id,
+    GValue * value, GParamSpec * pspec)
+{
+  RosBaseSink *sink = GST_ROS_BASE_SINK (object);
+
+  GST_DEBUG_OBJECT (sink, "get_property");
+  switch (property_id) {
+    case PROP_ROS_NAME:
+      g_value_set_string(value, sink->node_name);
+      break;
+
+    case PROP_ROS_NAMESPACE:
+      g_value_set_string(value, sink->node_namespace);
+      break;
+
+    case PROP_ROS_TOPIC:
+      g_value_set_string(value, sink->pub_topic);
+      break;
+
+    case PROP_ROS_FRAME_ID:
+      g_value_set_string(value, sink->frame_id);
+      break;
+
+    case PROP_ROS_ENCODING:
+      g_value_set_string(value, sink->encoding);
+      break;
+
+    case PROP_INIT_CAPS:
+      g_value_set_string(value, sink->init_caps);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+void rosbasesink_dispose (GObject * object)
+{
+  RosBaseSink *sink = GST_ROS_BASE_SINK (object);
+
+  GST_DEBUG_OBJECT (sink, "dispose");
+
+  /* clean up as possible.  may be called multiple times */
+
+  G_OBJECT_CLASS (rosbasesink_parent_class)->dispose (object);
+}
+
+void rosbasesink_finalize (GObject * object)
+{
+  RosBaseSink *sink = GST_ROS_BASE_SINK (object);
+
+  GST_DEBUG_OBJECT (sink, "finalize");
+
+  /* clean up object here */
+
+  G_OBJECT_CLASS (rosbasesink_parent_class)->finalize (object);
+}
+
+
+static GstStateChangeReturn rosbasesink_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  RosBaseSink *sink = GST_ROS_BASE_SINK (element);
+
+  switch (transition)
+  {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+    {
+      if (!rosbasesink_open(sink))
+      {
+        GST_DEBUG_OBJECT (sink, "open failed");
+        return GST_STATE_CHANGE_FAILURE;
+      }
+      break;
+    }
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+    {
+      sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->clock);
+      sink->msg_seq_num = 0;
+      break;
+    }
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (rosbasesink_parent_class)->change_state (element, transition);
+
+  switch (transition)
+  {
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      rosbasesink_close(sink);
+      break;
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+    default:
+      break;
+  }
+
+  return ret;
+
+}
+
+/* open the device with given specs */
+static gboolean rosbasesink_open (RosBaseSink * sink)
+{
+  RosBaseSinkClass *sink_class = GST_ROS_BASE_SINK_GET_CLASS (sink);
+  GST_DEBUG_OBJECT (sink, "open");
+
+  sink->ros_context = std::make_shared<rclcpp::Context>();
+  sink->ros_context->init(0, NULL);    // XXX should expose the init arg list
+  rclcpp::NodeOptions opts = rclcpp::NodeOptions();
+  opts.context(sink->ros_context); //set a context to generate the node in
+  sink->node = std::make_shared<rclcpp::Node>(std::string(sink->node_name), std::string(sink->node_namespace), opts);
+  rclcpp::QoS qos = rclcpp::SensorDataQoS().reliable();  //XXX add a parameter for overrides
+  //XXX add an executor and get sink->node->spin() running on a thread so reconf callbacks respond
+  if(NULL != sink_class->open)
+  {
+    sink_class->open(sink, sink->pub_topic, qos);
+  }
+
+  sink->logger = sink->node->get_logger();
+  sink->clock = sink->node->get_clock();
+  return TRUE;
+}
+
+/* close the device */
+static gboolean rosbasesink_close (RosBaseSink * sink)
+{
+  RosBaseSinkClass *sink_class = GST_ROS_BASE_SINK_GET_CLASS (sink);
+
+  GST_DEBUG_OBJECT (sink, "close");
+
+  sink->clock.reset();
+  if(NULL != sink_class->open)
+  {
+    sink_class->close(sink);
+  }
+  sink->node.reset();
+  sink->ros_context->shutdown("gst closing rosbasesink");
+  return TRUE;
+}
+
+static GstCaps * rosbasesink_fixate (GstBaseSink * base_sink, GstCaps * caps)
+{
+  //XXX check init_caps and fixate to that
+  GstStructure *s;
+  gint width, depth;
+  RosBaseSink *sink = GST_ROS_BASE_SINK (base_sink);
+
+  GST_DEBUG_OBJECT (sink, "fixate");
+
+  caps = gst_caps_make_writable (caps);
+
+  s = gst_caps_get_structure (caps, 0);
+
+  /* fields for all formats */
+  gst_structure_fixate_field_nearest_int (s, "rate", 44100);
+  gst_structure_fixate_field_nearest_int (s, "channels", 2);
+  gst_structure_fixate_field_nearest_int (s, "width", 16);
+
+  /* fields for int */
+  if (gst_structure_has_field (s, "depth")) {
+    gst_structure_get_int (s, "width", &width);
+    /* round width to nearest multiple of 8 for the depth */
+    depth = GST_ROUND_UP_8 (width);
+    gst_structure_fixate_field_nearest_int (s, "depth", depth);
+  }
+  if (gst_structure_has_field (s, "signed"))
+    gst_structure_fixate_field_boolean (s, "signed", TRUE);
+  if (gst_structure_has_field (s, "endianness"))
+    gst_structure_fixate_field_nearest_int (s, "endianness", G_BYTE_ORDER);
+
+  caps = GST_BASE_SINK_CLASS (rosbasesink_parent_class)->fixate (base_sink, caps);
+
+  return caps;
+}
+
+
+/* check the caps, register a node and open an publisher */
+static gboolean rosbasesink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
+{
+
+  return false;
+}
+
+
+
+static GstFlowReturn rosbasesink_render (GstBaseSink * base_sink, GstBuffer * buf)
+{
+  GstMapInfo info;
+  rclcpp::Time msg_time;
+  GstClockTimeDiff base_time;
+
+  RosBaseSink *sink = GST_ROS_BASE_SINK (base_sink);
+  
+  RosBaseSinkClass *sink_class = GST_ROS_BASE_SINK_GET_CLASS (sink);
+
+  GST_DEBUG_OBJECT (sink, "render");
+
+  // XXX use the base sink clock synchronising features
+  base_time = gst_element_get_base_time(GST_ELEMENT(sink));
+  msg_time = rclcpp::Time(GST_BUFFER_PTS(buf) + base_time + sink->ros_clock_offset, sink->clock->get_clock_type());
+
+  if(NULL != sink_class->render)
+  {
+    return sink_class->render(sink, buf, msg_time);
+  }
+
+  RCLCPP_ERROR(sink->logger, "rosbasesink render function not set, dropping buffer");
+
+  return GST_FLOW_OK;
+}
+

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -48,6 +48,7 @@ static void rosbasesink_init (RosBaseSink * rosbasesink);
 
 static gboolean rosbasesink_setcaps (GstBaseSink * sink, GstCaps * caps);
 static GstCaps * rosbasesink_getcaps (GstBaseSink * sink, GstCaps * caps);
+static gboolean rosbasesink__query (GstBaseSink * sink, GstQuery * query);
 static GstFlowReturn rosbasesink_render (GstBaseSink * sink, GstBuffer * buffer);
 
 
@@ -354,6 +355,21 @@ static GstCaps* rosbasesink_getcaps (GstBaseSink * base_sink, GstCaps * filter)
   return filter;
 }
 
+static gboolean
+gst_alsasink_query (GstBaseSink * base_sink, GstQuery * query)
+{
+  RosBaseSink *sink = GST_ROS_BASE_SINK (base_sink);
+  RosBaseSinkClass *sink_class = GST_ROS_BASE_SINK_GET_CLASS (sink);
+
+  gboolean res;
+
+  if (sink_class->query)
+    res = sink_class->query (sink, query);
+  else
+    res = FALSE;
+
+  return res;
+}
 
 static GstFlowReturn rosbasesink_render (GstBaseSink * base_sink, GstBuffer * buf)
 {

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -65,15 +65,6 @@ enum
 };
 
 
-/* pad templates */
-
-static GstStaticPadTemplate rosbasesink_sink_template =
-GST_STATIC_PAD_TEMPLATE ("sink",
-    GST_PAD_SINK,
-    GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (ROS_AUDIO_MSG_CAPS)
-    );
-
 /* class initialization */
 
 G_DEFINE_TYPE_WITH_CODE (RosBaseSink, rosbasesink, GST_TYPE_BASE_SINK,
@@ -88,12 +79,6 @@ static void rosbasesink_class_init (RosBaseSinkClass * klass)
 
   object_class->set_property = rosbasesink_set_property;
   object_class->get_property = rosbasesink_get_property;
-
-
-  /* Setting up pads and setting metadata should be moved to
-     base_class_init if you intend to subclass this class. */
-  gst_element_class_add_static_pad_template (element_class,
-      &rosbasesink_sink_template);
 
 
   gst_element_class_set_static_metadata (element_class,
@@ -207,7 +192,8 @@ static GstStateChangeReturn rosbasesink_change_state (GstElement * element, GstS
     }
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
     {
-      sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->clock);
+      sink->stream_start = sink->clock->now();
+      sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->stream_start);
       break;
     }
     case GST_STATE_CHANGE_READY_TO_PAUSED:

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -1,0 +1,289 @@
+/* GStreamer
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Suite 500,
+ * Boston, MA 02110-1335, USA.
+ */
+/**
+ * SECTION:element-rosbasesrc
+ *
+ * The rosbasesrc element, tie ROS2 into a src element.
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * gst-launch-1.0 -v rosaudiosrc ! queue ! audioconvert ! alsasink
+ * ]|
+ * plays audio data from ros over the default output.
+ * </refsect2>
+ */
+
+
+#include <gst_bridge/rosbasesrc.h>
+
+
+GST_DEBUG_CATEGORY_STATIC (rosbasesrc_debug_category);
+#define GST_CAT_DEFAULT rosbasesrc_debug_category
+
+/* prototypes */
+
+
+static void rosbasesrc_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
+static void rosbasesrc_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
+
+
+static GstStateChangeReturn rosbasesrc_change_state (GstElement * element, GstStateChange transition);
+static void rosbasesrc_init (RosBaseSrc * src);
+
+
+
+static gboolean rosbasesrc_open (RosBaseSrc * src);
+static gboolean rosbasesrc_close (RosBaseSrc * src);
+
+
+/*
+  XXX provide a mechanism for ROS to provide a clock
+*/
+
+
+enum
+{
+  PROP_0,
+  PROP_ROS_NAME,
+  PROP_ROS_NAMESPACE,
+    // XXX stream_start override
+
+};
+
+/* class initialization */
+
+G_DEFINE_TYPE_WITH_CODE (RosBaseSrc, rosbasesrc, GST_TYPE_BASE_SRC,
+    GST_DEBUG_CATEGORY_INIT (rosbasesrc_debug_category, "rosbasesrc", 0,
+        "debug category for rosbasesrc element"))
+
+static void rosbasesrc_class_init (RosBaseSrcClass * klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
+  GstBaseSrcClass *basesrc_class = (GstBaseSrcClass *) klass;
+
+  object_class->set_property = rosbasesrc_set_property;
+  object_class->get_property = rosbasesrc_get_property;
+
+  gst_element_class_set_static_metadata (element_class,
+      "rosbasesrc",
+      "Source",
+      "a gstreamer source class to place ROS nodes in gstreamer",
+      "BrettRD <brettrd@brettrd.com>");
+
+  g_object_class_install_property (object_class, PROP_ROS_NAME,
+      g_param_spec_string ("ros-name", "node-name", "Name of the ROS node",
+      "ros_base_src_node",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+  g_object_class_install_property (object_class, PROP_ROS_NAMESPACE,
+      g_param_spec_string ("ros-namespace", "node-namespace", "Namespace for the ROS node",
+      "",
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
+
+
+  element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesrc_change_state); //use state change events to open and close subscribers
+
+  //basesrc_class->create() // there's no reason for the base class to shim in here
+
+
+}
+
+static void rosbasesrc_init (RosBaseSrc * src)
+{
+  src->node_name = g_strdup("ros_base_src_node");
+  src->node_namespace = g_strdup("");
+}
+
+void rosbasesrc_set_property (GObject * object, guint property_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  RosBaseSrc *src = GST_ROS_BASE_SRC (object);
+
+  GST_DEBUG_OBJECT (src, "set_property");
+
+  switch (property_id) {
+    case PROP_ROS_NAME:
+      if(src->node)
+      {
+        RCLCPP_ERROR(src->logger, "can't change node name once openned");
+      }
+      else
+      {
+        g_free(src->node_name);
+        src->node_name = g_value_dup_string(value);
+      }
+      break;
+
+    case PROP_ROS_NAMESPACE:
+      if(src->node)
+      {
+        RCLCPP_ERROR(src->logger, "can't change node namespace once openned");
+      }
+      else
+      {
+        g_free(src->node_namespace);
+        src->node_namespace = g_value_dup_string(value);
+      }
+      break;
+
+    // XXX stream_start override
+
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+void rosbasesrc_get_property (GObject * object, guint property_id,
+    GValue * value, GParamSpec * pspec)
+{
+  RosBaseSrc *src = GST_ROS_BASE_SRC (object);
+
+  GST_DEBUG_OBJECT (src, "get_property");
+  switch (property_id)
+  {
+    case PROP_ROS_NAME:
+      g_value_set_string(value, src->node_name);
+      break;
+
+    case PROP_ROS_NAMESPACE:
+      g_value_set_string(value, src->node_namespace);
+      break;
+
+    // XXX stream_start override
+
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+
+static GstStateChangeReturn rosbasesrc_change_state (GstElement * element, GstStateChange transition)
+{
+  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
+  RosBaseSrc *src = GST_ROS_BASE_SRC (element);
+
+  switch (transition)
+  {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+    {
+      if (!rosbasesrc_open(src))
+      {
+        GST_DEBUG_OBJECT (src, "open failed");
+        return GST_STATE_CHANGE_FAILURE;
+      }
+      break;
+    }
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+    {
+      // XXX stream_start override 
+      src->stream_start = src->clock->now();
+      src->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(src), src->stream_start);
+      break;
+    }
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (rosbasesrc_parent_class)->change_state (element, transition);
+
+  switch (transition)
+  {
+    case GST_STATE_CHANGE_READY_TO_NULL:
+    {
+      rosbasesrc_close(src);
+      break;
+    }
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+    default:
+      break;
+  }
+
+  return ret;
+
+}
+
+/* open the device with given specs */
+static gboolean rosbasesrc_open (RosBaseSrc * src)
+{
+  RosBaseSrcClass *src_class = GST_ROS_BASE_SRC_GET_CLASS (src);
+  using std::placeholders::_1;
+
+  gboolean result = TRUE;
+
+  GST_DEBUG_OBJECT (src, "open");
+
+  src->ros_context = std::make_shared<rclcpp::Context>();
+  src->ros_context->init(0, NULL);    // XXX should expose the init arg list
+  auto opts = rclcpp::NodeOptions();
+  opts.context(src->ros_context); //set a context to generate the node in
+  src->node = std::make_shared<rclcpp::Node>(std::string(src->node_name), std::string(src->node_namespace), opts);
+
+  // A local ros context requires an executor to spin() on
+  auto ex_args = rclcpp::executor::ExecutorArgs();
+  ex_args.context = src->ros_context;
+  src->ros_executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>(ex_args);
+  src->ros_executor->add_node(src->node);
+
+  // allow sub-class to create subscribers on src->node
+  if(src_class->open)
+    result = src_class->open(src);
+
+  src->logger = src->node->get_logger();
+  src->clock = src->node->get_clock();
+
+  //src->ros_executor->spin();
+  src->ros_executor->spin_some();
+  // XXX create a thread
+
+  return result;
+}
+
+/* close the device */
+static gboolean rosbasesrc_close (RosBaseSrc * src)
+{
+  RosBaseSrcClass *src_class = GST_ROS_BASE_SRC_GET_CLASS (src);
+
+  GST_DEBUG_OBJECT (src, "close");
+  gboolean result = TRUE;
+
+  src->clock.reset();
+
+  //allow sub-class to clean up before destroying ros context
+  if(src_class->close)
+    result = src_class->close(src);
+
+  src->node.reset();
+  //XXX executor
+  src->ros_context->shutdown("gst closing rosbasesrc");
+  return result;
+}
+
+

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -53,6 +53,7 @@ static gboolean rosimagesink_open (RosBaseSink * sink);
 static gboolean rosimagesink_close (RosBaseSink * sink);
 static GstCaps * rosimagesink_getcaps (RosBaseSink * base_sink, GstCaps * filter);
 static gboolean rosimagesink_setcaps (RosBaseSink * base_sink, GstCaps * caps);
+static gboolean rosimagesink_query (RosBaseSink * sink, GstQuery * query);
 static GstFlowReturn rosimagesink_render (RosBaseSink * base_sink, GstBuffer * buffer, rclcpp::Time msg_time);
 
 enum
@@ -133,6 +134,7 @@ static void rosimagesink_class_init (RosimagesinkClass * klass)
   //supply the calls ros base sink needs to negotiate upstream formats and manage the publisher
   ros_base_sink_class->set_caps = GST_DEBUG_FUNCPTR (rosimagesink_setcaps);  //gstreamer informs us what caps we're using.
   ros_base_sink_class->get_caps = GST_DEBUG_FUNCPTR (rosimagesink_getcaps);  //gstreamer asks what caps we can deal with
+  ros_base_sink_class->query = GST_DEBUG_FUNCPTR (rosimagesink_query);  //gstreamer asks what caps we recommend
   ros_base_sink_class->open = GST_DEBUG_FUNCPTR (rosimagesink_open);  //let the base sink know how we register publishers
   ros_base_sink_class->close = GST_DEBUG_FUNCPTR (rosimagesink_close);  //let the base sink know how we destroy publishers
   ros_base_sink_class->render = GST_DEBUG_FUNCPTR (rosimagesink_render); // gives us a buffer to package
@@ -332,7 +334,7 @@ static gboolean rosimagesink_setcaps (RosBaseSink * ros_base_sink, GstCaps * cap
 
 static GstCaps* rosimagesink_getcaps (RosBaseSink * ros_base_sink, GstCaps * filter)
 {
-  //Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
+  Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
 
   //this is called several times during caps negotiation to decide on a pipeline format
   // if we return NULL, the base sink will simply fetch our template caps and offer that selection to the src.
@@ -343,6 +345,11 @@ static GstCaps* rosimagesink_getcaps (RosBaseSink * ros_base_sink, GstCaps * fil
   return filter;
 }
 
+static gboolean rosimagesink_query (RosBaseSink * sink, GstQuery * query)
+{
+
+  return FALSE;
+}
 
 static GstFlowReturn rosimagesink_render (RosBaseSink * ros_base_sink, GstBuffer * buf, rclcpp::Time msg_time)
 {

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2020 FIXME <fixme@example.com>
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -45,26 +45,15 @@ GST_DEBUG_CATEGORY_STATIC (rosimagesink_debug_category);
 
 
 static void rosimagesink_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
-
 static void rosimagesink_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
-static void rosimagesink_dispose (GObject * object);  //unused?
-static void rosimagesink_finalize (GObject * object);
 
-
-static GstStateChangeReturn rosimagesink_change_state (GstElement * element, GstStateChange transition);
 static void rosimagesink_init (Rosimagesink * sink);
-static gboolean rosimagesink_setcaps (GstBaseSink * base_sink, GstCaps * caps);
-static GstCaps * rosimagesink_fixate (GstBaseSink * base_sink, GstCaps * caps);
 
-static GstFlowReturn rosimagesink_render (GstBaseSink * base_sink, GstBuffer * buffer);
-
-static gboolean rosimagesink_open (Rosimagesink * sink);
-static gboolean rosimagesink_close (Rosimagesink * sink);
-
-/*
-  provide a mechanism for ROS to provide a clock
-*/
-
+static gboolean rosimagesink_open (RosBaseSink * sink);
+static gboolean rosimagesink_close (RosBaseSink * sink);
+static GstCaps * rosimagesink_getcaps (RosBaseSink * base_sink, GstCaps * filter);
+static gboolean rosimagesink_setcaps (RosBaseSink * base_sink, GstCaps * caps);
+static GstFlowReturn rosimagesink_render (RosBaseSink * base_sink, GstBuffer * buffer, rclcpp::Time msg_time);
 
 enum
 {
@@ -89,7 +78,7 @@ GST_STATIC_PAD_TEMPLATE ("sink",
 
 /* class initialization */
 
-G_DEFINE_TYPE_WITH_CODE (Rosimagesink, rosimagesink, GST_TYPE_BASE_SINK,
+G_DEFINE_TYPE_WITH_CODE (Rosimagesink, rosimagesink, GST_TYPE_ROS_BASE_SINK,
     GST_DEBUG_CATEGORY_INIT (rosimagesink_debug_category, "rosimagesink", 0,
         "debug category for rosimagesink element"))
 
@@ -97,13 +86,11 @@ static void rosimagesink_class_init (RosimagesinkClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
-  GstBaseSinkClass *basesink_class = (GstBaseSinkClass *) klass;
+  //GstBaseSinkClass *basesink_class = (GstBaseSinkClass *) klass;
+  RosBaseSinkClass *ros_base_sink_class = GST_ROS_BASE_SINK_CLASS (klass);
 
   object_class->set_property = rosimagesink_set_property;
   object_class->get_property = rosimagesink_get_property;
-  object_class->dispose = rosimagesink_dispose;
-  object_class->finalize = rosimagesink_finalize;
-
 
   /* Setting up pads and setting metadata should be moved to
      base_class_init if you intend to subclass this class. */
@@ -116,18 +103,6 @@ static void rosimagesink_class_init (RosimagesinkClass * klass)
       "Sink",
       "a gstreamer sink that publishes image data into ROS",
       "BrettRD <brettrd@brettrd.com>");
-
-  g_object_class_install_property (object_class, PROP_ROS_NAME,
-      g_param_spec_string ("ros-name", "node-name", "Name of the ROS node",
-      "gst_image_sink_node",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
-
-  g_object_class_install_property (object_class, PROP_ROS_NAMESPACE,
-      g_param_spec_string ("ros-namespace", "node-namespace", "Namespace for the ROS node",
-      "",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
 
   g_object_class_install_property (object_class, PROP_ROS_TOPIC,
       g_param_spec_string ("ros-topic", "pub-topic", "ROS topic to be published on",
@@ -153,26 +128,20 @@ static void rosimagesink_class_init (RosimagesinkClass * klass)
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
 
+  //basesink_class->  //access gstreamer base sink events here
 
-  element_class->change_state = GST_DEBUG_FUNCPTR (rosimagesink_change_state); //use state change events to open and close publishers
-  basesink_class->fixate = GST_DEBUG_FUNCPTR (rosimagesink_fixate); //set caps fields to our preferred values (if possible)
-  basesink_class->set_caps = GST_DEBUG_FUNCPTR (rosimagesink_setcaps);  //gstreamer informs us what caps we're using.
-  //basesink_class->event = GST_DEBUG_FUNCPTR (rosimagesink_event);  //flush events can cause discontinuities (flags exist in buffers)
-  //basesink_class->wait_event = GST_DEBUG_FUNCPTR (rosimagesink_wait_event); //eos events, finish rendering the output then return
-  //basesink_class->get_times = GST_DEBUG_FUNCPTR (rosimagesink_get_times); //asks us for start and stop times (?)
-  //basesink_class->preroll = GST_DEBUG_FUNCPTR (rosimagesink_preroll); //hands us the first buffer
-  basesink_class->render = GST_DEBUG_FUNCPTR (rosimagesink_render); // gives us a buffer to forward
-  //basesink_class->activate_pull = GST_DEBUG_FUNCPTR (rosimagesink_activate_pull);  //lets the sink drive the pipeline scheduling (useful for synchronising a file into a rosbag playback)
-
+  //supply the calls ros base sink needs to negotiate upstream formats and manage the publisher
+  ros_base_sink_class->set_caps = GST_DEBUG_FUNCPTR (rosimagesink_setcaps);  //gstreamer informs us what caps we're using.
+  ros_base_sink_class->get_caps = GST_DEBUG_FUNCPTR (rosimagesink_getcaps);  //gstreamer asks what caps we can deal with
+  ros_base_sink_class->open = GST_DEBUG_FUNCPTR (rosimagesink_open);  //let the base sink know how we register publishers
+  ros_base_sink_class->close = GST_DEBUG_FUNCPTR (rosimagesink_close);  //let the base sink know how we destroy publishers
+  ros_base_sink_class->render = GST_DEBUG_FUNCPTR (rosimagesink_render); // gives us a buffer to package
 }
 
 static void rosimagesink_init (Rosimagesink * sink)
 {
-  // Don't register the node or the publisher just yet,
-  // wait for rosimagesink_open()
-  // XXX set defaults elsewhere to keep gst-inspect consistent
-  sink->node_name = g_strdup("gst_image_sink_node");
-  sink->node_namespace = g_strdup("");
+  RosBaseSink *ros_base_sink GST_ROS_BASE_SINK(sink);
+  ros_base_sink->node_name = g_strdup("gst_image_sink_node");
   sink->pub_topic = g_strdup("gst_image_pub");
   sink->frame_id = g_strdup("image_frame");
   sink->encoding = g_strdup("");
@@ -182,39 +151,16 @@ static void rosimagesink_init (Rosimagesink * sink)
 void rosimagesink_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
+  RosBaseSink *ros_base_sink = GST_ROS_BASE_SINK(object);
   Rosimagesink *sink = GST_ROSIMAGESINK (object);
 
   GST_DEBUG_OBJECT (sink, "set_property");
 
   switch (property_id) {
-    case PROP_ROS_NAME:
-      if(sink->node)
-      {
-        RCLCPP_ERROR(sink->logger, "can't change node name once openned");
-      }
-      else
-      {
-        g_free(sink->node_name);
-        sink->node_name = g_value_dup_string(value);
-      }
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      if(sink->node)
-      {
-        RCLCPP_ERROR(sink->logger, "can't change node namespace once openned");
-      }
-      else
-      {
-        g_free(sink->node_namespace);
-        sink->node_namespace = g_value_dup_string(value);
-      }
-      break;
-
     case PROP_ROS_TOPIC:
-      if(sink->node)
+      if(ros_base_sink->node)
       {
-        RCLCPP_ERROR(sink->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_sink->logger, "can't change topic name once openned");
       }
       else
       {
@@ -234,16 +180,15 @@ void rosimagesink_set_property (GObject * object, guint property_id,
       break;
 
     case PROP_INIT_CAPS:
-      if(sink->node)  // XXX wrong condition, but close enough
+      if(ros_base_sink->node)  // XXX wrong condition, but close enough
       {
-        RCLCPP_ERROR(sink->logger, "can't change initial caps after init");
+        RCLCPP_ERROR(ros_base_sink->logger, "can't change initial caps after init");
       }
       else
       {
         g_free(sink->init_caps);
         sink->init_caps = g_value_dup_string(value);
         // XXX set up the image message checks and unpack the caps
-        // XXX return the init_caps in fixate(), and probably earlier than that
       }
       break;
 
@@ -260,14 +205,6 @@ void rosimagesink_get_property (GObject * object, guint property_id,
 
   GST_DEBUG_OBJECT (sink, "get_property");
   switch (property_id) {
-    case PROP_ROS_NAME:
-      g_value_set_string(value, sink->node_name);
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      g_value_set_string(value, sink->node_namespace);
-      break;
-
     case PROP_ROS_TOPIC:
       g_value_set_string(value, sink->pub_topic);
       break;
@@ -290,142 +227,27 @@ void rosimagesink_get_property (GObject * object, guint property_id,
   }
 }
 
-void rosimagesink_dispose (GObject * object)
-{
-  Rosimagesink *sink = GST_ROSIMAGESINK (object);
-
-  GST_DEBUG_OBJECT (sink, "dispose");
-
-  /* clean up as possible.  may be called multiple times */
-
-  G_OBJECT_CLASS (rosimagesink_parent_class)->dispose (object);
-}
-
-void rosimagesink_finalize (GObject * object)
-{
-  Rosimagesink *sink = GST_ROSIMAGESINK (object);
-
-  GST_DEBUG_OBJECT (sink, "finalize");
-
-  /* clean up object here */
-
-  G_OBJECT_CLASS (rosimagesink_parent_class)->finalize (object);
-}
-
-
-static GstStateChangeReturn rosimagesink_change_state (GstElement * element, GstStateChange transition)
-{
-  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
-  Rosimagesink *sink = GST_ROSIMAGESINK (element);
-  GST_DEBUG_OBJECT (sink, "change state");
-
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_NULL_TO_READY:
-    {
-      if (!rosimagesink_open(sink))
-      {
-        GST_DEBUG_OBJECT (sink, "open failed");
-        return GST_STATE_CHANGE_FAILURE;
-      }
-      break;
-    }
-    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-    {
-      sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->clock);
-      break;
-    }
-    case GST_STATE_CHANGE_READY_TO_PAUSED:
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  ret = GST_ELEMENT_CLASS (rosimagesink_parent_class)->change_state (element, transition);
-
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_READY_TO_NULL:
-      rosimagesink_close(sink);
-      break;
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  return ret;
-
-}
-
 /* open the device with given specs */
-static gboolean rosimagesink_open (Rosimagesink * sink)
+static gboolean rosimagesink_open (RosBaseSink * ros_base_sink)
 {
+  Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
   GST_DEBUG_OBJECT (sink, "open");
-
-  sink->ros_context = std::make_shared<rclcpp::Context>();
-  sink->ros_context->init(0, NULL);    // XXX should expose the init arg list
-  rclcpp::NodeOptions opts = rclcpp::NodeOptions();
-  opts.context(sink->ros_context); //set a context to generate the node in
-  sink->node = std::make_shared<rclcpp::Node>(std::string(sink->node_name), std::string(sink->node_namespace), opts);
   rclcpp::QoS qos = rclcpp::SensorDataQoS().reliable();  //XXX add a parameter for overrides
-  sink->pub = sink->node->create_publisher<sensor_msgs::msg::Image>(sink->pub_topic, qos);
-  sink->logger = sink->node->get_logger();
-  sink->clock = sink->node->get_clock();
+  sink->pub = ros_base_sink->node->create_publisher<sensor_msgs::msg::Image>(sink->pub_topic, qos);
   return TRUE;
 }
 
 /* close the device */
-static gboolean rosimagesink_close (Rosimagesink * sink)
+static gboolean rosimagesink_close (RosBaseSink * ros_base_sink)
 {
+  Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
   GST_DEBUG_OBJECT (sink, "close");
-
-  sink->clock.reset();
   sink->pub.reset();
-  sink->node.reset();
-  sink->ros_context->shutdown("gst closing rosimagesink");
   return TRUE;
 }
 
-static GstCaps * rosimagesink_fixate (GstBaseSink * base_sink, GstCaps * caps)
-{
-  //XXX check init_caps and fixate to that
-  GstStructure *s;
-  gint width, depth;
-  Rosimagesink *sink = GST_ROSIMAGESINK (base_sink);
-
-  GST_DEBUG_OBJECT (sink, "fixate");
-
-  caps = gst_caps_make_writable (caps);
-
-  s = gst_caps_get_structure (caps, 0);
-
-  /* fields for all formats */
-  //gst_structure_fixate_field_nearest_int (s, "framerate", 25);
-  gst_structure_fixate_field_nearest_int (s, "width", 640);
-  gst_structure_fixate_field_nearest_int (s, "height", 480);
-
-  /* fields for int */
-  if (gst_structure_has_field (s, "depth")) {
-    gst_structure_get_int (s, "width", &width);
-    /* round width to nearest multiple of 8 for the depth */
-    depth = GST_ROUND_UP_8 (width);
-    gst_structure_fixate_field_nearest_int (s, "depth", depth);
-  }
-  if (gst_structure_has_field (s, "signed"))
-    gst_structure_fixate_field_boolean (s, "signed", TRUE);
-  if (gst_structure_has_field (s, "endianness"))
-    gst_structure_fixate_field_nearest_int (s, "endianness", G_BYTE_ORDER);
-
-  caps = GST_BASE_SINK_CLASS (rosimagesink_parent_class)->fixate (base_sink, caps);
-
-  return caps;
-}
-
-
 /* check the caps, register a node and open an publisher */
-static gboolean rosimagesink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
+static gboolean rosimagesink_setcaps (RosBaseSink * ros_base_sink, GstCaps * caps)
 {
   GstStructure *caps_struct;
   gint width, height, depth, endianness, rate_num, rate_den;
@@ -433,27 +255,27 @@ static gboolean rosimagesink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
   GstVideoFormat format_enum;
   const GstVideoFormatInfo * format_info;
 
-  Rosimagesink *sink = GST_ROSIMAGESINK (base_sink);
+  Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
 
   GST_DEBUG_OBJECT (sink, "setcaps");
 
   if(!gst_caps_is_fixed(caps))
   {
-    RCLCPP_ERROR(sink->logger, "caps is not fixed");
+    RCLCPP_ERROR(ros_base_sink->logger, "caps is not fixed");
   }
 
 
-  if(sink->node)
-      RCLCPP_INFO(sink->logger, "preparing video with caps '%s'",
+  if(ros_base_sink->node)
+      RCLCPP_INFO(ros_base_sink->logger, "preparing video with caps '%s'",
           gst_caps_to_string(caps));
 
   caps_struct = gst_caps_get_structure (caps, 0);
   if(!gst_structure_get_int (caps_struct, "width", &width))
-      RCLCPP_ERROR(sink->logger, "setcaps missing width");
+      RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing width");
   if(!gst_structure_get_int (caps_struct, "height", &height))
-      RCLCPP_ERROR(sink->logger, "setcaps missing height");
+      RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing height");
   if(!gst_structure_get_fraction (caps_struct, "framerate", &rate_num, &rate_den))
-      RCLCPP_ERROR(sink->logger, "setcaps missing framerate");
+      RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing framerate");
 
   format_str = gst_structure_get_string(caps_struct, "format");
 
@@ -476,24 +298,24 @@ static gboolean rosimagesink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
       sink->encoding = g_strdup(gst_bridge::getRosEncoding(format_enum).c_str());
     }
 
-    RCLCPP_INFO(sink->logger, "setcaps format string is %s ", format_str);
-    RCLCPP_INFO(sink->logger, "setcaps n_components is %d", format_info->n_components);
-    RCLCPP_INFO(sink->logger, "setcaps bits is %d", format_info->bits);
-    RCLCPP_INFO(sink->logger, "setcaps pixel_stride is %d", depth);
+    RCLCPP_INFO(ros_base_sink->logger, "setcaps format string is %s ", format_str);
+    RCLCPP_INFO(ros_base_sink->logger, "setcaps n_components is %d", format_info->n_components);
+    RCLCPP_INFO(ros_base_sink->logger, "setcaps bits is %d", format_info->bits);
+    RCLCPP_INFO(ros_base_sink->logger, "setcaps pixel_stride is %d", depth);
 
     if(format_info->bits < 8)
     {
       depth = depth/8;
-      RCLCPP_ERROR(sink->logger, "low bits per pixel");
+      RCLCPP_ERROR(ros_base_sink->logger, "low bits per pixel");
     }
 
     //endianness = format_info->endianness;
   }
   else
   {
-    RCLCPP_ERROR(sink->logger, "setcaps missing format");
+    RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing format");
     if(!gst_structure_get_int (caps_struct, "endianness", &endianness))
-        RCLCPP_ERROR(sink->logger, "setcaps missing endianness");
+        RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing endianness");
   }
 
 
@@ -508,20 +330,27 @@ static gboolean rosimagesink_setcaps (GstBaseSink * base_sink, GstCaps * caps)
 }
 
 
+static GstCaps* rosimagesink_getcaps (RosBaseSink * ros_base_sink, GstCaps * filter)
+{
+  //Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
 
-static GstFlowReturn rosimagesink_render (GstBaseSink * base_sink, GstBuffer * buf)
+  //this is called several times during caps negotiation to decide on a pipeline format
+  // if we return NULL, the base sink will simply fetch our template caps and offer that selection to the src.
+
+  //XXX this is extremely fragile, and only works for very narrow parameters where caps negotiation is short-cut
+  //XXX look at alsasink, there's an intersection function in there to narrow down on what's possible
+
+  return filter;
+}
+
+
+static GstFlowReturn rosimagesink_render (RosBaseSink * ros_base_sink, GstBuffer * buf, rclcpp::Time msg_time)
 {
   GstMapInfo info;
-  rclcpp::Time msg_time;
-  GstClockTimeDiff base_time;
   sensor_msgs::msg::Image msg;
 
-  Rosimagesink *sink = GST_ROSIMAGESINK (base_sink);
+  Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
   GST_DEBUG_OBJECT (sink, "render");
-
-  // XXX use the base sink clock synchronising features
-  base_time = gst_element_get_base_time(GST_ELEMENT(sink));
-  msg_time = rclcpp::Time(GST_BUFFER_PTS(buf) + base_time + sink->ros_clock_offset, sink->clock->get_clock_type());
 
   msg.header.stamp = msg_time;
   msg.header.frame_id = sink->frame_id;

--- a/gst_bridge/src/rosimagesrc.cpp
+++ b/gst_bridge/src/rosimagesrc.cpp
@@ -30,11 +30,7 @@
  * </refsect2>
  */
 
-//#ifdef HAVE_CONFIG_H
-//#include "config.h"
-//#endif
 
-#include <gst/gst.h>
 #include <gst_bridge/rosimagesrc.h>
 
 GST_DEBUG_CATEGORY_STATIC (rosimagesrc_debug_category);
@@ -45,31 +41,20 @@ GST_DEBUG_CATEGORY_STATIC (rosimagesrc_debug_category);
 
 static void rosimagesrc_set_property (GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
 static void rosimagesrc_get_property (GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
-static void rosimagesrc_dispose (GObject * object);  //unused?
-static void rosimagesrc_finalize (GObject * object);
-
-
-static GstStateChangeReturn rosimagesrc_change_state (GstElement * element, GstStateChange transition);
-
 
 static void rosimagesrc_init (Rosimagesrc * src);
-static GstCaps * rosimagesrc_fixate (GstBaseSrc * base_src, GstCaps * caps);
+
+static gboolean rosimagesrc_open (RosBaseSrc * ros_base_src);
+static gboolean rosimagesrc_close (RosBaseSrc * ros_base_src);
 static GstFlowReturn rosimagesrc_create (GstBaseSrc * base_src, guint64 offset, guint size, GstBuffer **buf);
 
-static gboolean rosimagesrc_query (GstBaseSrc * base_src, GstQuery * query);
-
-static gboolean rosimagesrc_open (Rosimagesrc * src);
-static gboolean rosimagesrc_close (Rosimagesrc * src);
-
 //static gboolean rosimagesrc_negotiate (GstBaseSrc * base_src);
-static GstCaps* rosimagesrc_getcaps (GstBaseSrc * base_src, GstCaps * filter);  //set our caps preferences
 //static GstCaps* rosimagesrc_setcaps (GstBaseSrc * base_src, GstCaps * caps);  //upstream returns any remaining caps preferences
+static gboolean rosimagesrc_query (GstBaseSrc * base_src, GstQuery * query);
+static GstCaps* rosimagesrc_getcaps (GstBaseSrc * base_src, GstCaps * filter);  //set our caps preferences
+static GstCaps * rosimagesrc_fixate (GstBaseSrc * base_src, GstCaps * caps);
 
 
-/*
- * rosimagesrc_create needs to wait for a ros message arriving on rosimagesrc_sub_cb
- * excuse the gross mix of C++ and C styling going on here, it had to happen somewhere.
- */
 static void rosimagesrc_sub_cb(Rosimagesrc * src, sensor_msgs::msg::Image::ConstSharedPtr msg);
 static sensor_msgs::msg::Image::ConstSharedPtr rosimagesrc_wait_for_msg(Rosimagesrc * src);
 
@@ -79,16 +64,9 @@ static void rosimagesrc_set_msg_props_from_msg(Rosimagesrc * src, sensor_msgs::m
 static void rosimagesrc_set_msg_props(Rosimagesrc * src, int width, int height, size_t step, gint endianness, gchar* encoding);
 
 
-/*
-  XXX provide a mechanism for ROS to provide a clock
-*/
-
-
 enum
 {
   PROP_0,
-  PROP_ROS_NAME,
-  PROP_ROS_NAMESPACE,
   PROP_ROS_TOPIC,
   PROP_ROS_FRAME_ID,
   PROP_ROS_ENCODING,
@@ -107,7 +85,7 @@ GST_STATIC_PAD_TEMPLATE ("src",
 
 /* class initialization */
 
-G_DEFINE_TYPE_WITH_CODE (Rosimagesrc, rosimagesrc, GST_TYPE_BASE_SRC,
+G_DEFINE_TYPE_WITH_CODE (Rosimagesrc, rosimagesrc, GST_TYPE_ROS_BASE_SRC,
     GST_DEBUG_CATEGORY_INIT (rosimagesrc_debug_category, "rosimagesrc", 0,
         "debug category for rosimagesrc element"))
 
@@ -115,13 +93,11 @@ static void rosimagesrc_class_init (RosimagesrcClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
-  GstBaseSrcClass *basesrc_class = (GstBaseSrcClass *) klass;
+  GstBaseSrcClass *basesrc_class = GST_BASE_SRC_CLASS (klass);
+  RosBaseSrcClass *ros_base_src_class = GST_ROS_BASE_SRC_CLASS (klass);
 
   object_class->set_property = rosimagesrc_set_property;
   object_class->get_property = rosimagesrc_get_property;
-  object_class->dispose = rosimagesrc_dispose;
-  object_class->finalize = rosimagesrc_finalize;
-
 
   /* Setting up pads and setting metadata should be moved to
      base_class_init if you intend to subclass this class. */
@@ -134,18 +110,6 @@ static void rosimagesrc_class_init (RosimagesrcClass * klass)
       "Source/Video",
       "a gstreamer source that transports ROS image_msgs over gstreamer",
       "BrettRD <brettrd@brettrd.com>");
-
-  g_object_class_install_property (object_class, PROP_ROS_NAME,
-      g_param_spec_string ("ros-name", "node-name", "Name of the ROS node",
-      "gst_image_src_node",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
-
-  g_object_class_install_property (object_class, PROP_ROS_NAMESPACE,
-      g_param_spec_string ("ros-namespace", "node-namespace", "Namespace for the ROS node",
-      "",
-      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  );
 
   g_object_class_install_property (object_class, PROP_ROS_TOPIC,
       g_param_spec_string ("ros-topic", "sub-topic", "ROS topic to subscribe to",
@@ -172,25 +136,23 @@ static void rosimagesrc_class_init (RosimagesrcClass * klass)
   );
 
 
+  ros_base_src_class->open = GST_DEBUG_FUNCPTR (rosimagesrc_open);  //let the base sink know how we register publishers
+  ros_base_src_class->close = GST_DEBUG_FUNCPTR (rosimagesrc_close);  //let the base sink know how we destroy publishers
+  basesrc_class->create = GST_DEBUG_FUNCPTR(rosimagesrc_create);
 
-  element_class->change_state = GST_DEBUG_FUNCPTR (rosimagesrc_change_state); //use state change events to open and close subscribers
 
-  basesrc_class->fixate = GST_DEBUG_FUNCPTR (rosimagesrc_fixate); //set caps fields to our preferred values (if possible)
   basesrc_class->get_caps = GST_DEBUG_FUNCPTR (rosimagesrc_getcaps);  //return caps within the filter
+  basesrc_class->query = GST_DEBUG_FUNCPTR(rosimagesrc_query);  //set the scheduling modes
+  basesrc_class->fixate = GST_DEBUG_FUNCPTR (rosimagesrc_fixate); //set caps fields to our preferred values (if possible)
   //basesrc_class->negotiate = GST_DEBUG_FUNCPTR (rosimagesrc_negotiate);  //start figuring out caps and allocators
   //basesrc_class->event = GST_DEBUG_FUNCPTR (rosimagesrc_event);  //flush events can cause discontinuities (flags exist in buffers)
   //basesrc_class->get_times = GST_DEBUG_FUNCPTR (rosimagesrc_get_times); //asks us for start and stop times (?)
-  basesrc_class->create = GST_DEBUG_FUNCPTR(rosimagesrc_create);
-  basesrc_class->query = GST_DEBUG_FUNCPTR(rosimagesrc_query);  //set the scheduling modes
 }
 
 static void rosimagesrc_init (Rosimagesrc * src)
 {
-  // Don't register the node or the subscriber just yet,
-  // wait for rosimagesrc_open()
-  // XXX set defaults elsewhere to keep gst-inspect consistent
-  src->node_name = g_strdup("gst_image_src_node");
-  src->node_namespace = g_strdup("");
+  RosBaseSrc *ros_base_src GST_ROS_BASE_SRC(src);
+  ros_base_src->node_name = g_strdup("gst_image_src_node");
   src->sub_topic = g_strdup("gst_image_sub");
   src->frame_id = g_strdup("");
   src->encoding = g_strdup("");
@@ -211,39 +173,17 @@ static void rosimagesrc_init (Rosimagesrc * src)
 void rosimagesrc_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (object);
   Rosimagesrc *src = GST_ROSIMAGESRC (object);
 
   GST_DEBUG_OBJECT (src, "set_property");
 
-  switch (property_id) {
-    case PROP_ROS_NAME:
-      if(src->node)
-      {
-        RCLCPP_ERROR(src->logger, "can't change node name once openned");
-      }
-      else
-      {
-        g_free(src->node_name);
-        src->node_name = g_value_dup_string(value);
-      }
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      if(src->node)
-      {
-        RCLCPP_ERROR(src->logger, "can't change node namespace once openned");
-      }
-      else
-      {
-        g_free(src->node_namespace);
-        src->node_namespace = g_value_dup_string(value);
-      }
-      break;
-
+  switch (property_id)
+  {
     case PROP_ROS_TOPIC:
-      if(src->node)
+      if(ros_base_src->node)
       {
-        RCLCPP_ERROR(src->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_src->logger, "can't change topic name once openned");
       }
       else
       {
@@ -261,7 +201,7 @@ void rosimagesrc_set_property (GObject * object, guint property_id,
       }
       else
       {
-        RCLCPP_ERROR(src->logger, "can't change initial caps after init");
+        RCLCPP_ERROR(ros_base_src->logger, "can't change initial caps after init");
       }
       break;
 
@@ -279,14 +219,6 @@ void rosimagesrc_get_property (GObject * object, guint property_id,
   GST_DEBUG_OBJECT (src, "get_property");
   switch (property_id)
   {
-    case PROP_ROS_NAME:
-      g_value_set_string(value, src->node_name);
-      break;
-
-    case PROP_ROS_NAMESPACE:
-      g_value_set_string(value, src->node_namespace);
-      break;
-
     case PROP_ROS_TOPIC:
       g_value_set_string(value, src->sub_topic);
       break;
@@ -308,29 +240,6 @@ void rosimagesrc_get_property (GObject * object, guint property_id,
       break;
   }
 }
-
-void rosimagesrc_dispose (GObject * object)
-{
-  Rosimagesrc *src = GST_ROSIMAGESRC (object);
-
-  GST_DEBUG_OBJECT (src, "dispose");
-
-  /* clean up as possible.  may be called multiple times */
-
-  G_OBJECT_CLASS (rosimagesrc_parent_class)->dispose (object);
-}
-
-void rosimagesrc_finalize (GObject * object)
-{
-  Rosimagesrc *src = GST_ROSIMAGESRC (object);
-
-  GST_DEBUG_OBJECT (src, "finalize");
-
-  /* clean up object here */
-
-  G_OBJECT_CLASS (rosimagesrc_parent_class)->finalize (object);
-}
-
 
 static void rosimagesrc_set_msg_props_from_caps_string(Rosimagesrc * src, gchar * caps_string)
 {
@@ -402,102 +311,40 @@ static void rosimagesrc_set_msg_props(Rosimagesrc * src, int width, int height, 
 }
 
 
-static GstStateChangeReturn rosimagesrc_change_state (GstElement * element, GstStateChange transition)
+/* open the subscription with given specs */
+static gboolean rosimagesrc_open (RosBaseSrc * ros_base_src)
 {
-  GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
-  Rosimagesrc *src = GST_ROSIMAGESRC (element);
+  Rosimagesrc *src = GST_ROSIMAGESRC (ros_base_src);
 
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_NULL_TO_READY:
-    {
-      if (!rosimagesrc_open(src))
-      {
-        GST_DEBUG_OBJECT (src, "open failed");
-        return GST_STATE_CHANGE_FAILURE;
-      }
-      break;
-    }
-    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
-    {
-      src->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(src), src->clock);
-      break;
-    }
-    case GST_STATE_CHANGE_READY_TO_PAUSED:
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  ret = GST_ELEMENT_CLASS (rosimagesrc_parent_class)->change_state (element, transition);
-
-  switch (transition)
-  {
-    case GST_STATE_CHANGE_READY_TO_NULL:
-    {
-      rosimagesrc_close(src);
-      break;
-    }
-    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-    default:
-      break;
-  }
-
-  return ret;
-
-}
-
-/* open the device with given specs */
-static gboolean rosimagesrc_open (Rosimagesrc * src)
-{
   using std::placeholders::_1;
 
   GST_DEBUG_OBJECT (src, "open");
-
-  src->ros_context = std::make_shared<rclcpp::Context>();
-  src->ros_context->init(0, NULL);    // XXX should expose the init arg list
-  auto opts = rclcpp::NodeOptions();
-  opts.context(src->ros_context); //set a context to generate the node in
-  src->node = std::make_shared<rclcpp::Node>(std::string(src->node_name), std::string(src->node_namespace), opts);
-
-  // A local ros context requires an executor to spin() on
-  auto ex_args = rclcpp::executor::ExecutorArgs();
-  ex_args.context = src->ros_context;
-  src->ros_executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>(ex_args);
-  src->ros_executor->add_node(src->node);
 
   // ROS can't cope with some forms of std::bind being passed as subscriber callbacks,
   // lambdas seem to be the preferred case for these instances
   auto cb = [src] (sensor_msgs::msg::Image::ConstSharedPtr msg){rosimagesrc_sub_cb(src, msg);};
   rclcpp::QoS qos = rclcpp::SensorDataQoS();  //XXX add a parameter for overrides
-  src->sub = src->node->create_subscription<sensor_msgs::msg::Image>(src->sub_topic, qos, cb);
-
-  src->logger = src->node->get_logger();
-  src->clock = src->node->get_clock();
-  //src->ros_executor->spin();
-  src->ros_executor->spin_some();
-
+  src->sub = ros_base_src->node->create_subscription<sensor_msgs::msg::Image>(src->sub_topic, qos, cb);
 
   return TRUE;
 }
 
 /* close the device */
-static gboolean rosimagesrc_close (Rosimagesrc * src)
-{
+static gboolean rosimagesrc_close (RosBaseSrc * ros_base_src)
+{ 
+  Rosimagesrc *src = GST_ROSIMAGESRC (ros_base_src);
+
   GST_DEBUG_OBJECT (src, "close");
 
-  src->clock.reset();
   src->sub.reset();
-  src->node.reset();
-  src->ros_context->shutdown("gst closing rosimagesrc");
   return TRUE;
 }
 
 
 static GstCaps * rosimagesrc_fixate (GstBaseSrc * base_src, GstCaps * caps)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (base_src);
+
   GstStructure *s;
   gint width, depth;
 
@@ -523,8 +370,8 @@ static GstCaps * rosimagesrc_fixate (GstBaseSrc * base_src, GstCaps * caps)
 
   caps = GST_BASE_SRC_CLASS (rosimagesrc_parent_class)->fixate (base_src, caps);
 
-  if(src->node)
-      RCLCPP_INFO(src->logger, "preparing video with caps '%s'",
+  if(ros_base_src->node)
+      RCLCPP_INFO(ros_base_src->logger, "preparing video with caps '%s'",
           gst_caps_to_string(caps));
 
   return caps;
@@ -533,6 +380,8 @@ static GstCaps * rosimagesrc_fixate (GstBaseSrc * base_src, GstCaps * caps)
 /* return valid caps to parent class*/
 static GstCaps* rosimagesrc_getcaps (GstBaseSrc * base_src, GstCaps * filter)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (base_src);
+
   const gchar * format_str;
   GstVideoFormat format_enum;
   static sensor_msgs::msg::Image::ConstSharedPtr msg;
@@ -542,20 +391,20 @@ static GstCaps* rosimagesrc_getcaps (GstBaseSrc * base_src, GstCaps * filter)
 
   GST_DEBUG_OBJECT (src, "getcaps");
 
-  if(src->node)
-      RCLCPP_INFO(src->logger, "getcaps with filter '%s'", gst_caps_to_string(filter));
+  if(ros_base_src->node)
+      RCLCPP_INFO(ros_base_src->logger, "getcaps with filter '%s'", gst_caps_to_string(filter));
 
   // if init_caps is not set, we wait for the first message
   // if init_caps is set, we don't wait
   if(0 == g_strcmp0(src->init_caps, ""))
   {
-    if(!src->node)
+    if(!ros_base_src->node)
     {
       GST_DEBUG_OBJECT (src, "getcaps with node not ready, returning template");
       return gst_pad_get_pad_template_caps (GST_BASE_SRC (src)->srcpad);
     }
     GST_DEBUG_OBJECT (src, "getcaps with node ready, waiting for message");
-    RCLCPP_INFO(src->logger, "waiting for first message");
+    RCLCPP_INFO(ros_base_src->logger, "waiting for first message");
     msg = rosimagesrc_wait_for_msg(src);  // XXX need to fix API, the action happens in a side-effect
 
     format_enum = gst_bridge::getGstVideoFormat(std::string(src->encoding));
@@ -616,17 +465,18 @@ static gboolean rosimagesrc_query (GstBaseSrc * base_src, GstQuery * query)
  */
 static GstFlowReturn rosimagesrc_create (GstBaseSrc * base_src, guint64 offset, guint size, GstBuffer **buf)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (base_src);
+  Rosimagesrc *src = GST_ROSIMAGESRC (base_src);
+
   GstMapInfo info;
   GstClockTimeDiff base_time;
   size_t length;
   GstFlowReturn ret = GST_FLOW_OK;
   GstBuffer *res_buf;
 
-  Rosimagesrc *src = GST_ROSIMAGESRC (base_src);
-
   GST_DEBUG_OBJECT (src, "create");
 
-  if(!src->node)
+  if(!ros_base_src->node)
   {
     GST_DEBUG_OBJECT (src, "ros image creating buffer before node init");
   }
@@ -662,15 +512,16 @@ static GstFlowReturn rosimagesrc_create (GstBaseSrc * base_src, guint64 offset, 
   gst_buffer_unmap (*buf, &info);
 
   base_time = gst_element_get_base_time(GST_ELEMENT(src));
-  GST_BUFFER_PTS (*buf) = rclcpp::Time(msg->header.stamp).nanoseconds() - src->ros_clock_offset - base_time;
+  GST_BUFFER_PTS (*buf) = rclcpp::Time(msg->header.stamp).nanoseconds() - ros_base_src->ros_clock_offset - base_time;
 
   return ret;
 }
 
 static void rosimagesrc_sub_cb(Rosimagesrc * src, sensor_msgs::msg::Image::ConstSharedPtr msg)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (src);
   //GST_DEBUG_OBJECT (src, "ros cb called");
-  //RCLCPP_DEBUG(src->logger, "ros cb called");
+  //RCLCPP_DEBUG(ros_base_src->logger, "ros cb called");
 
   //fetch caps from the first msg, check on subsequent
   if(src->msg_init)
@@ -680,15 +531,15 @@ static void rosimagesrc_sub_cb(Rosimagesrc * src, sensor_msgs::msg::Image::Const
   else
   {
     if(!(src->step == msg->step / msg->width))
-      RCLCPP_ERROR(src->logger, "image format changed during playback, step %d != %d", src->step, msg->step/msg->width);
+      RCLCPP_ERROR(ros_base_src->logger, "image format changed during playback, step %d != %d", src->step, msg->step/msg->width);
     if(!(src->height == (int) msg->height))
-      RCLCPP_ERROR(src->logger, "image format changed during playback, height %d != %d", src->height, msg->height);
+      RCLCPP_ERROR(ros_base_src->logger, "image format changed during playback, height %d != %d", src->height, msg->height);
     if(!(src->width == (int) msg->width))
-      RCLCPP_ERROR(src->logger, "image format changed during playback, width %d != %d", src->width, msg->width);
+      RCLCPP_ERROR(ros_base_src->logger, "image format changed during playback, width %d != %d", src->width, msg->width);
     if(!(src->endianness == (msg->is_bigendian ? G_BIG_ENDIAN : G_LITTLE_ENDIAN)))
-      RCLCPP_ERROR(src->logger, "image format changed during playback, endianness %d != %d", src->endianness, (msg->is_bigendian ? G_BIG_ENDIAN : G_LITTLE_ENDIAN));
+      RCLCPP_ERROR(ros_base_src->logger, "image format changed during playback, endianness %d != %d", src->endianness, (msg->is_bigendian ? G_BIG_ENDIAN : G_LITTLE_ENDIAN));
     if(!(0 == g_strcmp0(src->encoding, msg->encoding.c_str())))
-      RCLCPP_ERROR(src->logger, "image format changed during playback, encoding %s != %s", src->encoding, msg->encoding.c_str());
+      RCLCPP_ERROR(ros_base_src->logger, "image format changed during playback, encoding %s != %s", src->encoding, msg->encoding.c_str());
     
   }
 
@@ -698,6 +549,8 @@ static void rosimagesrc_sub_cb(Rosimagesrc * src, sensor_msgs::msg::Image::Const
 
 static sensor_msgs::msg::Image::ConstSharedPtr rosimagesrc_wait_for_msg(Rosimagesrc * src)
 {
+  RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (src);
+
   std::promise<sensor_msgs::msg::Image::ConstSharedPtr> new_msg;
   src->new_msg = std::move(new_msg);
   std::shared_future<sensor_msgs::msg::Image::ConstSharedPtr> fut(src->new_msg.get_future());
@@ -706,10 +559,10 @@ static sensor_msgs::msg::Image::ConstSharedPtr rosimagesrc_wait_for_msg(Rosimage
   
   do
   {
-    ret = src->ros_executor->spin_until_future_complete(fut);
+    ret = ros_base_src->ros_executor->spin_until_future_complete(fut);
     if(ret == rclcpp::FutureReturnCode::INTERRUPTED)
     {
-      RCLCPP_INFO(src->logger, "wait for cb got interrupted");
+      RCLCPP_INFO(ros_base_src->logger, "wait for cb got interrupted");
     }
   }
   while(ret != rclcpp::FutureReturnCode::SUCCESS);


### PR DESCRIPTION
This change allows new sources and sinks to be created with less boilerplate, and should allow other users to create new packages to with new element collections with specific dependencies.

This also collects some particularly sinister issues into two files.
In particular, https://github.com/BrettRD/ros-gst-bridge/issues/4 needs a thread to call spin() from.  This can go in rosbasesrc and rosbasesink and fix all derived elements in a later patch.
