### PR TITLE
allow ros2 timestamps to be overridden

### DIFF
--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -50,10 +50,12 @@ struct _RosBaseSink
   rclcpp::Node::SharedPtr node;
   rclcpp::Logger logger;
   rclcpp::Clock::SharedPtr clock;
-  rclcpp::Time stream_start;
-  GstClockTimeDiff ros_clock_offset;
+
   std::thread spin_thread;
 
+  rclcpp::Time stream_start;
+  rcl_time_point_value_t stream_start_prop; //uint64_t, equiv to GST_TYPE_CLOCK_TIME
+  GstClockTimeDiff ros_clock_offset;
 };
 
 struct _RosBaseSinkClass

--- a/gst_bridge/include/gst_bridge/rosbasesrc.h
+++ b/gst_bridge/include/gst_bridge/rosbasesrc.h
@@ -50,10 +50,12 @@ struct _RosBaseSrc
   rclcpp::Node::SharedPtr node;
   rclcpp::Logger logger;
   rclcpp::Clock::SharedPtr clock;
-  rclcpp::Time stream_start;
-  std::thread spin_thread;
-  GstClockTimeDiff ros_clock_offset;
 
+  std::thread spin_thread;
+
+  rclcpp::Time stream_start;
+  rcl_time_point_value_t stream_start_prop; //uint64_t, equiv to GST_TYPE_CLOCK_TIME
+  GstClockTimeDiff ros_clock_offset;
 };
 
 struct _RosBaseSrcClass

--- a/gst_bridge/src/rosaudiosink.cpp
+++ b/gst_bridge/src/rosaudiosink.cpp
@@ -146,7 +146,7 @@ void rosaudiosink_set_property (GObject * object, guint property_id,
     case PROP_ROS_TOPIC:
       if(ros_base_sink->node)
       {
-        RCLCPP_ERROR(ros_base_sink->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_sink->logger, "can't change topic name once opened");
         // XXX try harder
       }
       else

--- a/gst_bridge/src/rosaudiosrc.cpp
+++ b/gst_bridge/src/rosaudiosrc.cpp
@@ -186,7 +186,7 @@ void rosaudiosrc_set_property (GObject * object, guint property_id,
     case PROP_ROS_TOPIC:
       if(ros_base_src->node)
       {
-        RCLCPP_ERROR(ros_base_src->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_src->logger, "can't change topic name once opened");
       }
       else
       {

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -130,7 +130,7 @@ void rosbasesink_set_property (GObject * object, guint property_id,
     case PROP_ROS_NAME:
       if(sink->node)
       {
-        RCLCPP_ERROR(sink->logger, "can't change node name once openned");
+        RCLCPP_ERROR(sink->logger, "can't change node name once opened");
       }
       else
       {
@@ -142,7 +142,7 @@ void rosbasesink_set_property (GObject * object, guint property_id,
     case PROP_ROS_NAMESPACE:
       if(sink->node)
       {
-        RCLCPP_ERROR(sink->logger, "can't change node namespace once openned");
+        RCLCPP_ERROR(sink->logger, "can't change node namespace once opened");
       }
       else
       {
@@ -154,7 +154,7 @@ void rosbasesink_set_property (GObject * object, guint property_id,
     case PROP_ROS_START_TIME:
       if(sink->node)
       {
-        RCLCPP_ERROR(sink->logger, "can't change start_time once openned");
+        RCLCPP_ERROR(sink->logger, "can't change start_time once opened");
       }
       else
       {

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -63,6 +63,7 @@ enum
   PROP_0,
   PROP_ROS_NAME,
   PROP_ROS_NAMESPACE,
+  PROP_ROS_START_TIME,
 };
 
 
@@ -100,6 +101,11 @@ static void rosbasesink_class_init (RosBaseSinkClass * klass)
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
 
+  g_object_class_install_property (object_class, PROP_ROS_START_TIME,
+      g_param_spec_uint64 ("ros-start-time", "ros-start-time", "ROS time (nanoseconds) of the first message",
+      0, (guint64)(-1), GST_CLOCK_TIME_NONE,
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
 
   element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesink_change_state); //use state change events to open and close publishers
   basesink_class->render = GST_DEBUG_FUNCPTR (rosbasesink_render); // gives us a buffer to forward
@@ -108,11 +114,9 @@ static void rosbasesink_class_init (RosBaseSinkClass * klass)
 
 static void rosbasesink_init (RosBaseSink * sink)
 {
-  // Don't register the node or the publisher just yet,
-  // wait for rosbasesink_open()
-  // XXX set defaults elsewhere to keep gst-inspect consistent
   sink->node_name = g_strdup("gst_base_sink_node");
   sink->node_namespace = g_strdup("");
+  sink->stream_start_prop = GST_CLOCK_TIME_NONE;
 }
 
 void rosbasesink_set_property (GObject * object, guint property_id,
@@ -147,6 +151,17 @@ void rosbasesink_set_property (GObject * object, guint property_id,
       }
       break;
 
+    case PROP_ROS_START_TIME:
+      if(sink->node)
+      {
+        RCLCPP_ERROR(sink->logger, "can't change start_time once openned");
+      }
+      else
+      {
+        sink->stream_start_prop = g_value_get_uint64(value);
+      }
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -166,6 +181,12 @@ void rosbasesink_get_property (GObject * object, guint property_id,
 
     case PROP_ROS_NAMESPACE:
       g_value_set_string(value, sink->node_namespace);
+      break;
+
+    case PROP_ROS_START_TIME:
+      g_value_set_uint64(value, sink->stream_start.nanoseconds());
+      // XXX this allows inspection via props,
+      //      but may cause confusion because it does not show the actual prop
       break;
 
     default:
@@ -193,7 +214,18 @@ static GstStateChangeReturn rosbasesink_change_state (GstElement * element, GstS
     }
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
     {
-      sink->stream_start = sink->clock->now();
+      if(GST_CLOCK_TIME_IS_VALID(sink->stream_start_prop))
+      {
+        sink->stream_start = rclcpp::Time(
+          sink->stream_start_prop, sink->clock->get_clock_type());
+        RCLCPP_INFO(sink->logger, "stream_start overridden to %ld", sink->stream_start.nanoseconds());
+      }
+      else
+      {
+        sink->stream_start = sink->clock->now();
+        RCLCPP_INFO(sink->logger, "stream_start at %ld", sink->stream_start.nanoseconds());
+      }
+
       sink->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(sink), sink->stream_start);
       break;
     }

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -131,7 +131,7 @@ void rosbasesrc_set_property (GObject * object, guint property_id,
     case PROP_ROS_NAME:
       if(src->node)
       {
-        RCLCPP_ERROR(src->logger, "can't change node name once openned");
+        RCLCPP_ERROR(src->logger, "can't change node name once opened");
       }
       else
       {
@@ -143,7 +143,7 @@ void rosbasesrc_set_property (GObject * object, guint property_id,
     case PROP_ROS_NAMESPACE:
       if(src->node)
       {
-        RCLCPP_ERROR(src->logger, "can't change node namespace once openned");
+        RCLCPP_ERROR(src->logger, "can't change node namespace once opened");
       }
       else
       {
@@ -155,7 +155,7 @@ void rosbasesrc_set_property (GObject * object, guint property_id,
     case PROP_ROS_START_TIME:
       if(src->node)
       {
-        RCLCPP_ERROR(src->logger, "can't change start_time once openned");
+        RCLCPP_ERROR(src->logger, "can't change start_time once opened");
       }
       else
       {

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -64,8 +64,7 @@ enum
   PROP_0,
   PROP_ROS_NAME,
   PROP_ROS_NAMESPACE,
-    // XXX stream_start override
-
+  PROP_ROS_START_TIME,
 };
 
 /* class initialization */
@@ -78,7 +77,7 @@ static void rosbasesrc_class_init (RosBaseSrcClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
-  GstBaseSrcClass *basesrc_class = (GstBaseSrcClass *) klass;
+  //GstBaseSrcClass *basesrc_class = (GstBaseSrcClass *) klass;
 
   object_class->set_property = rosbasesrc_set_property;
   object_class->get_property = rosbasesrc_get_property;
@@ -101,6 +100,11 @@ static void rosbasesrc_class_init (RosBaseSrcClass * klass)
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
 
+  g_object_class_install_property (object_class, PROP_ROS_START_TIME,
+      g_param_spec_uint64 ("ros-start-time", "ros-start-time", "ROS time (nanoseconds) of the first message",
+      0, (guint64)(-1), GST_CLOCK_TIME_NONE,
+      (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  );
 
   element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesrc_change_state); //use state change events to open and close subscribers
 
@@ -113,6 +117,7 @@ static void rosbasesrc_init (RosBaseSrc * src)
 {
   src->node_name = g_strdup("ros_base_src_node");
   src->node_namespace = g_strdup("");
+  src->stream_start_prop = GST_CLOCK_TIME_NONE;
 }
 
 void rosbasesrc_set_property (GObject * object, guint property_id,
@@ -147,8 +152,16 @@ void rosbasesrc_set_property (GObject * object, guint property_id,
       }
       break;
 
-    // XXX stream_start override
-
+    case PROP_ROS_START_TIME:
+      if(src->node)
+      {
+        RCLCPP_ERROR(src->logger, "can't change start_time once openned");
+      }
+      else
+      {
+        src->stream_start_prop = g_value_get_uint64(value);
+      }
+      break;
 
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -172,8 +185,11 @@ void rosbasesrc_get_property (GObject * object, guint property_id,
       g_value_set_string(value, src->node_namespace);
       break;
 
-    // XXX stream_start override
-
+    case PROP_ROS_START_TIME:
+      g_value_set_uint64(value, src->stream_start.nanoseconds());
+      // XXX this allows inspection via props,
+      //      but may cause confusion because it does not show the actual prop
+      break;
 
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -200,13 +216,23 @@ static GstStateChangeReturn rosbasesrc_change_state (GstElement * element, GstSt
     }
     case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
     {
-      // XXX stream_start override 
-      // XXX flush subscription queues
-      src->stream_start = src->clock->now();
+      if(GST_CLOCK_TIME_IS_VALID(src->stream_start_prop))
+      {
+        src->stream_start = rclcpp::Time(
+          src->stream_start_prop, src->clock->get_clock_type());
+        RCLCPP_INFO(src->logger, "stream_start overridden to %ld", src->stream_start.nanoseconds());
+      }
+      else
+      {
+        src->stream_start = src->clock->now();
+        RCLCPP_INFO(src->logger, "stream_start at %ld", src->stream_start.nanoseconds());
+      }
+
       src->ros_clock_offset = gst_bridge::sample_clock_offset(GST_ELEMENT_CLOCK(src), src->stream_start);
       break;
     }
     case GST_STATE_CHANGE_READY_TO_PAUSED:
+    //XXX stop the subscription
     case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
     case GST_STATE_CHANGE_PAUSED_TO_READY:
     default:

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -149,7 +149,7 @@ void rosimagesink_set_property (GObject * object, guint property_id,
     case PROP_ROS_TOPIC:
       if(ros_base_sink->node)
       {
-        RCLCPP_ERROR(ros_base_sink->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_sink->logger, "can't change topic name once opened");
       }
       else
       {

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -282,14 +282,14 @@ static gboolean rosimagesink_setcaps (GstBaseSink * gst_base_sink, GstCaps * cap
       depth = depth/8;
       RCLCPP_ERROR(ros_base_sink->logger, "low bits per pixel");
     }
-
-    //endianness = format_info->endianness;
+    endianness = GST_VIDEO_FORMAT_INFO_IS_LE(format_info) ? G_LITTLE_ENDIAN : G_BIG_ENDIAN;
   }
   else
   {
     RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing format");
     if(!gst_structure_get_int (caps_struct, "endianness", &endianness))
-        RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing endianness");
+      RCLCPP_ERROR(ros_base_sink->logger, "setcaps missing endianness");
+    return false;
   }
 
 

--- a/gst_bridge/src/rosimagesrc.cpp
+++ b/gst_bridge/src/rosimagesrc.cpp
@@ -186,7 +186,7 @@ void rosimagesrc_set_property (GObject * object, guint property_id,
     case PROP_ROS_TOPIC:
       if(ros_base_src->node)
       {
-        RCLCPP_ERROR(ros_base_src->logger, "can't change topic name once openned");
+        RCLCPP_ERROR(ros_base_src->logger, "can't change topic name once opened");
       }
       else
       {


### PR DESCRIPTION
This adds a `ros-start-time` element property to all elements
Following https://github.com/BrettRD/ros-gst-bridge/issues/13, this allows a gstreamer prop to specify the ros2 time a stream's timestamps should start at.

At the moment, it is only writable before stream start, and only via launch description.
The `ros-start-time` element property should be readable at runtime via `Simplebin` automatic prop-param bindings.
This readable value is the start time used to timestamp the running stream, and can be used to re-play a stream with approximately original time stamps.

This does not offer compatibility with the `/clock` topic, and does not respect `use_sim_time`
When rosbag stabilises, this feature might need to change significantly

Another pull request should offer a ros clock server based on the pipeline time
