### PR TITLE
Add UYVY and YUY2 encoding

### DIFF
--- a/gst_bridge/include/gst_bridge/gst_bridge.h
+++ b/gst_bridge/include/gst_bridge/gst_bridge.h
@@ -30,7 +30,7 @@
 #include <sensor_msgs/image_encodings.hpp>
 #include <audio_msgs/msg/audio.hpp>
 
-#define GST_BRIDGE_GST_VIDEO_FORMAT_LIST "{ GRAY8, GRAY16_LE, RGB, BGR, RGBA, BGRA }"
+#define GST_BRIDGE_GST_VIDEO_FORMAT_LIST "{ GRAY8, GRAY16_LE, RGB, BGR, RGBA, BGRA, UYVY, YUY2 }"
 #define GST_BRIDGE_GST_AUDIO_FORMAT_LIST "{ S8, U8, S16LE, U16LE, S32LE, U32LE, F32LE, F64LE }"    // only well behaved formats
 
 // The following audio formats are theoretically ok, but might be more trouble than they're worth.

--- a/gst_bridge/src/gst_bridge.cpp
+++ b/gst_bridge/src/gst_bridge.cpp
@@ -32,12 +32,14 @@ GstClockTimeDiff sample_clock_offset(GstClock* gst_clock, rclcpp::Time stream_st
 // convert between ROS and GST types, only fully transparent mappings
 GstVideoFormat getGstVideoFormat(const std::string & encoding)
 {
-  if (encoding == sensor_msgs::image_encodings::MONO8)  {return GST_VIDEO_FORMAT_GRAY8;}
-  if (encoding == sensor_msgs::image_encodings::MONO16) {return GST_VIDEO_FORMAT_GRAY16_LE;}
-  if (encoding == sensor_msgs::image_encodings::RGB8)   {return GST_VIDEO_FORMAT_RGB;}
-  if (encoding == sensor_msgs::image_encodings::BGR8)   {return GST_VIDEO_FORMAT_BGR;}
-  if (encoding == sensor_msgs::image_encodings::RGBA8)  {return GST_VIDEO_FORMAT_RGBA;}
-  if (encoding == sensor_msgs::image_encodings::BGRA8)  {return GST_VIDEO_FORMAT_BGRA;}
+  if (encoding == sensor_msgs::image_encodings::MONO8)       {return GST_VIDEO_FORMAT_GRAY8;}
+  if (encoding == sensor_msgs::image_encodings::MONO16)      {return GST_VIDEO_FORMAT_GRAY16_LE;}
+  if (encoding == sensor_msgs::image_encodings::RGB8)        {return GST_VIDEO_FORMAT_RGB;}
+  if (encoding == sensor_msgs::image_encodings::BGR8)        {return GST_VIDEO_FORMAT_BGR;}
+  if (encoding == sensor_msgs::image_encodings::RGBA8)       {return GST_VIDEO_FORMAT_RGBA;}
+  if (encoding == sensor_msgs::image_encodings::BGRA8)       {return GST_VIDEO_FORMAT_BGRA;}
+  if (encoding == sensor_msgs::image_encodings::YUV422)      {return GST_VIDEO_FORMAT_UYVY;}
+  if (encoding == sensor_msgs::image_encodings::YUV422_YUY2) {return GST_VIDEO_FORMAT_YUY2;}
   return GST_VIDEO_FORMAT_UNKNOWN;
 }
 
@@ -49,6 +51,8 @@ std::string getRosEncoding(GstVideoFormat format)
   if (format == GST_VIDEO_FORMAT_BGR)       {return sensor_msgs::image_encodings::BGR8;}
   if (format == GST_VIDEO_FORMAT_RGBA)      {return sensor_msgs::image_encodings::RGBA8;}
   if (format == GST_VIDEO_FORMAT_BGRA)      {return sensor_msgs::image_encodings::BGRA8;}
+  if (format == GST_VIDEO_FORMAT_UYVY)      {return sensor_msgs::image_encodings::YUV422;}
+  if (format == GST_VIDEO_FORMAT_YUY2)      {return sensor_msgs::image_encodings::YUV422_YUY2;}
   return "unknown";
 }
 


### PR DESCRIPTION
Hi,
I added support for UYVY and YUY2 encoding in the gst_bridge and tested it with rqt_image_view. Now it is possible to do
```
gst-launch-1.0 --gst-plugin-path=install/gst_bridge/lib/gst_bridge/ videotestsrc ! "video/x-raw, format=UYVY" ! rosimagesink
```
and
```
gst-launch-1.0 --gst-plugin-path=install/gst_bridge/lib/gst_bridge/ videotestsrc ! "video/x-raw, format=YUY2" ! rosimagesink
```
without videoconvert before rosimagesink.