### PR TITLE
feat: add manual time offset to rosimagesink image publisher

### DIFF
--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -43,6 +43,7 @@ struct _RosBaseSink
   GstBaseSink parent;
   gchar* node_name;
   gchar* node_namespace;
+  gint64 offset_time_ns;
 
   rclcpp::Context::SharedPtr ros_context;
   rclcpp::Executor::SharedPtr ros_executor;

--- a/gst_bridge/include/gst_bridge/rosimagesink.h
+++ b/gst_bridge/include/gst_bridge/rosimagesink.h
@@ -26,6 +26,7 @@
 
 //include ROS and ROS message formats
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/duration.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -106,12 +106,6 @@ static void rosbasesrc_class_init (RosBaseSrcClass * klass)
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
 
-  // g_object_class_install_property (object_class, PROP_ROS_TIME_OFFSET,
-  //     g_param_spec_uint64 ("ros-time-offset", "ros-start-time", "A time offset to be added to each message stamp (nanoseconds)",
-  //     0, (guint64)(-1), GST_CLOCK_TIME_NONE,
-  //     (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
-  // );
-
   element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesrc_change_state); //use state change events to open and close subscribers
 
   //basesrc_class->create() // there's no reason for the base class to shim in here

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -64,6 +64,7 @@ enum
   PROP_ROS_NAME,
   PROP_ROS_NAMESPACE,
   PROP_ROS_START_TIME,
+  PROP_ROS_TIME_OFFSET,
 };
 
 /* class initialization */
@@ -104,6 +105,12 @@ static void rosbasesrc_class_init (RosBaseSrcClass * klass)
       0, (guint64)(-1), GST_CLOCK_TIME_NONE,
       (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
   );
+
+  // g_object_class_install_property (object_class, PROP_ROS_TIME_OFFSET,
+  //     g_param_spec_uint64 ("ros-time-offset", "ros-start-time", "A time offset to be added to each message stamp (nanoseconds)",
+  //     0, (guint64)(-1), GST_CLOCK_TIME_NONE,
+  //     (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS))
+  // );
 
   element_class->change_state = GST_DEBUG_FUNCPTR (rosbasesrc_change_state); //use state change events to open and close subscribers
 

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -314,10 +314,11 @@ static GstFlowReturn rosimagesink_render (RosBaseSink * ros_base_sink, GstBuffer
   int32_t sec = 0;
   uint32_t nsec = 0;
 
-  // Make duration an absolute value due to object definition
+  // Make duration an absolute value due to duration object definition
   if (abs(ros_base_sink->offset_time_ns) > G_MAXUINT32)
   {
     //need to to convert value to a integer value of seconds while leaving the rest in nanosecs to maintain precision
+    //as nsec of Duration is an uint32 object.
     RCLCPP_DEBUG(ros_base_sink->logger, "time offset is greater than 32 bits");
     sec = static_cast<int32_t>(abs(ros_base_sink->offset_time_ns) / G_GINT64_CONSTANT(1000000000));
     nsec = static_cast<uint32_t>(abs(ros_base_sink->offset_time_ns) - (sec * G_GINT64_CONSTANT(1000000000)));
@@ -330,15 +331,14 @@ static GstFlowReturn rosimagesink_render (RosBaseSink * ros_base_sink, GstBuffer
 
   rclcpp::Duration offset_time(sec, nsec);
 
-  
   if (ros_base_sink->offset_time_ns < 0)
   {
-    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is negative %f seconds or %ld nano", offset_time.seconds(), offset_time.nanoseconds());
+    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is negative %f seconds or %ld nanosecs", offset_time.seconds(), offset_time.nanoseconds());
     msg_time = msg_time - offset_time;
   }
   else
   {
-    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is positive %f seconds or %ld nano", offset_time.seconds(), offset_time.nanoseconds());
+    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is positive %f seconds or %ld nanosecs", offset_time.seconds(), offset_time.nanoseconds());
     msg_time = msg_time + offset_time;
   }
 

--- a/gst_bridge/src/rosimagesink.cpp
+++ b/gst_bridge/src/rosimagesink.cpp
@@ -37,6 +37,7 @@
 #include <gst_bridge/rosimagesink.h>
 
 
+
 GST_DEBUG_CATEGORY_STATIC (rosimagesink_debug_category);
 #define GST_CAT_DEFAULT rosimagesink_debug_category
 
@@ -309,6 +310,37 @@ static GstFlowReturn rosimagesink_render (RosBaseSink * ros_base_sink, GstBuffer
 
   Rosimagesink *sink = GST_ROSIMAGESINK (ros_base_sink);
   GST_DEBUG_OBJECT (sink, "render");
+
+  int32_t sec = 0;
+  uint32_t nsec = 0;
+
+  // Make duration an absolute value due to object definition
+  if (abs(ros_base_sink->offset_time_ns) > G_MAXUINT32)
+  {
+    //need to to convert value to a integer value of seconds while leaving the rest in nanosecs to maintain precision
+    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is greater than 32 bits");
+    sec = static_cast<int32_t>(abs(ros_base_sink->offset_time_ns) / G_GINT64_CONSTANT(1000000000));
+    nsec = static_cast<uint32_t>(abs(ros_base_sink->offset_time_ns) - (sec * G_GINT64_CONSTANT(1000000000)));
+  }
+  else
+  {
+    sec = 0;
+    nsec = static_cast<uint32_t>(abs(ros_base_sink->offset_time_ns));
+  }
+
+  rclcpp::Duration offset_time(sec, nsec);
+
+  
+  if (ros_base_sink->offset_time_ns < 0)
+  {
+    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is negative %f seconds or %ld nano", offset_time.seconds(), offset_time.nanoseconds());
+    msg_time = msg_time - offset_time;
+  }
+  else
+  {
+    RCLCPP_DEBUG(ros_base_sink->logger, "time offset is positive %f seconds or %ld nano", offset_time.seconds(), offset_time.nanoseconds());
+    msg_time = msg_time + offset_time;
+  }
 
   msg.header.stamp = msg_time;
   msg.header.frame_id = sink->frame_id;


### PR DESCRIPTION
This feature enables an offset time specified in nanoseconds to modify the timestamp of the published ros image topic. A parameter ros-time-offset is added as a specifier to rosimagesink.

Usage Example adds 10s to the current timestamp of a published image: 
`gst-launch-1.0 videotestsrc pattern=ball ! video/x-raw, format=RGB,width=1280,height=720 ! timeoverlay ! queue ! rosimagesink ros-topic=test/image ros-name='gst_rosimagesink_camera' ros-namespace='gst' ros-frame-id='camera_frame' ros-time-offset=10000000000 throttle-time=0 `