### PR TITLE
Add libsoup dependency

### DIFF
--- a/gst_pipeline_plugins_webrtc/package.xml
+++ b/gst_pipeline_plugins_webrtc/package.xml
@@ -15,6 +15,7 @@
 
   <build_depend>libgstreamer1.0-dev</build_depend>
   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
+  <build_depend>libsoup2.4-dev</build_depend>
 
   <build_depend>std_msgs</build_depend>
   <build_depend>gst_msgs</build_depend>


### PR DESCRIPTION
Added libsoup as a build dependency. 

Note that this requires the following addition to the ros index to come through first:
 https://github.com/ros/rosdistro/pull/40241