### PR TITLE
Register gstreamer plugin automatically.

### DIFF
--- a/gst_bridge/CMakeLists.txt
+++ b/gst_bridge/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
+ament_environment_hooks(register_plugin.dsv.in)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 

--- a/gst_bridge/register_plugin.dsv.in
+++ b/gst_bridge/register_plugin.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GST_PLUGIN_PATH;lib/@PROJECT_NAME@/


### PR DESCRIPTION
This uses an environment hook to register the plugin in the `GST_PLUGIN_PATH` environment variable automatically when the workspace / package is sourced.

This way you don't have to specify the path to the plugin everytime you run `gst-launch-1.0` or `gst-inspect-1.0`

This currently only works in source workspaces due to ros2/ros2#1613.
DSV should be cross-platform and work on Windows as well, but I have never tested that.