### PR TITLE
Update rosdep dependencies of gst_pipeline_plugins_webrtc package 

### DIFF
--- a/gst_pipeline_plugins_webrtc/package.xml
+++ b/gst_pipeline_plugins_webrtc/package.xml
@@ -16,6 +16,7 @@
   <build_depend>libgstreamer1.0-dev</build_depend>
   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
   <build_depend>libsoup2-dev</build_depend>
+  <build_depend>libjson-glib</build_depend>
 
   <build_depend>std_msgs</build_depend>
   <build_depend>gst_msgs</build_depend>

--- a/gst_pipeline_plugins_webrtc/package.xml
+++ b/gst_pipeline_plugins_webrtc/package.xml
@@ -15,7 +15,7 @@
 
   <build_depend>libgstreamer1.0-dev</build_depend>
   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
-  <build_depend>libsoup2.4-dev</build_depend>
+  <build_depend>libsoup2-dev</build_depend>
 
   <build_depend>std_msgs</build_depend>
   <build_depend>gst_msgs</build_depend>

--- a/gst_pipeline_plugins_webrtc/package.xml
+++ b/gst_pipeline_plugins_webrtc/package.xml
@@ -15,6 +15,7 @@
 
   <build_depend>libgstreamer1.0-dev</build_depend>
   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
+  <build_depend>libgstreamer-plugins-bad1.0-dev</build_depend>
   <build_depend>libsoup2-dev</build_depend>
   <build_depend>libjson-glib</build_depend>
 


### PR DESCRIPTION
This pull request follows up on #65. Thanks to @fbe555, `libsoup`, `json-glib-1.0`, and `libgstreamer-plugins-bad1.0-dev` have been added to rosindex. This PR updates `package.xml` accordingly and modifies the `libsoup` dependency to match its actual rosindex record.  

I've also verified and can confirm that all three dependencies are required to successfully build the package 