### PR TITLE
Fix for non compiling on aarch64 architectures of gst_pipeline_plugins

### DIFF
--- a/gst_pipeline_plugins/CMakeLists.txt
+++ b/gst_pipeline_plugins/CMakeLists.txt
@@ -38,9 +38,8 @@ pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 IMPORTED_TARGET)
 pkg_check_modules(GST_RTP REQUIRED gstreamer-rtp-1.0 IMPORTED_TARGET)
 
 
-# XXX Hack around a linker bug
-add_library(mygstrtp SHARED IMPORTED)
-set_target_properties(mygstrtp PROPERTIES IMPORTED_LOCATION /usr/lib/x86_64-linux-gnu/libgstrtp-1.0.so)
+include(FindPkgConfig)
+pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-plugins-base-1.0 gstreamer-pbutils-1.0)
 
 
 ## Include messages
@@ -75,7 +74,7 @@ add_library(${PROJECT_NAME} SHARED
 
 )
 
-target_link_libraries(${PROJECT_NAME} mygstrtp)
+target_link_libraries(${PROJECT_NAME} ${GST_LIBRARIES})
 
 ament_target_dependencies(${PROJECT_NAME}
   gst_pipeline


### PR DESCRIPTION
As I had problems compiling the ros-gst-bridge on an arm based platform, I looked into it and discovered that the gst_pipeline_plugins add a fixed import of /usr/lib/x86_64-linux-gnu/libgstrtp-1.0.so, which breaks on non c86_64 machines.

I used a different include method for the gstreamer modules, which should fix this error and also compiles on aarch64 machines for me.

I hope this can be useful to you.