### PR TITLE
Timestamping is now handled by respective base classes (src / sink) + new raw nodes

### DIFF
--- a/gst_bridge/CMakeLists.txt
+++ b/gst_bridge/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(std_msgs REQUIRED)
 find_package(audio_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(gst_msgs REQUIRED)
 
 
 ###########
@@ -68,6 +69,7 @@ target_include_directories(gst_bridge PUBLIC
   ${rclcpp_INCLUDE_DIRS}
   ${sensor_msgs_INCLUDE_DIRS}
   ${audio_msgs_INCLUDE_DIRS}
+  ${gst_msgs_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   ${GLIB_INCLUDE_DIRS}
@@ -77,6 +79,7 @@ target_link_libraries(gst_bridge PUBLIC
   ${rclcpp_LIBRARIES}
   ${sensor_msgs_LIBRARIES}
   ${audio_msgs_LIBRARIES}
+  ${gst_msgs_LIBRARIES}
   ${GLIB_LIBRARIES}
   ${GLIB_GIO_LIBRARIES}
   PkgConfig::gstreamer
@@ -99,6 +102,8 @@ add_library(rosgstbridge SHARED
   src/rosaudiosrc.cpp
   src/rosimagesrc.cpp
   src/rostextsrc.cpp
+  src/rosrawsrc.cpp
+  src/rosrawsink.cpp
 )
 
 

--- a/gst_bridge/include/gst_bridge/rosbasesink.h
+++ b/gst_bridge/include/gst_bridge/rosbasesink.h
@@ -41,11 +41,29 @@ G_BEGIN_DECLS
 typedef struct _RosBaseSink RosBaseSink;
 typedef struct _RosBaseSinkClass RosBaseSinkClass;
 
+typedef enum {
+  TIMESTAMP_MODE_ROS_OFFSET = 0,
+  TIMESTAMP_MODE_REFERENCE = 1,
+  TIMESTAMP_MODE_PTS = 2
+} RosTimestampMode;
+
+#define GST_TYPE_ROS_TIMESTAMP_MODE (gst_ros_timestamp_mode_get_type())
+
+typedef enum {
+  CONVERSION_MODE_NONE = 0,
+  CONVERSION_MODE_NTP_2_UNIX = 1,
+} TimestampConversionMode;
+
+#define GST_TYPE_TIMESTAMP_CONVERSION_MODE (gst_timestamp_conversion_mode_get_type())
+
+
 struct _RosBaseSink
 {
   GstBaseSink parent;
   gchar * node_name;
   gchar * node_namespace;
+  RosTimestampMode timestamp_mode;
+  TimestampConversionMode timestamp_conversion_mode;
 
   // private variables to construct the node interfaces
   RosBaseImp local_node;

--- a/gst_bridge/include/gst_bridge/rosbasesrc.h
+++ b/gst_bridge/include/gst_bridge/rosbasesrc.h
@@ -46,6 +46,7 @@ struct _RosBaseSrc
   GstBaseSrc parent;
   gchar * node_name;
   gchar * node_namespace;
+  gboolean attach_reference_timestamp;
 
   // private variables to construct the node interfaces
   RosBaseImp local_node;
@@ -81,10 +82,12 @@ struct _RosBaseSrcClass
   gboolean (*close)(RosBaseSrc * src);
 
   gboolean (*notify_thread)(RosBaseSrc * src);
-
 };
 
 GType rosbasesrc_get_type(void);
+
+void set_timestamps(
+  GstBuffer ** buffer, RosBaseSrc * src, GstElement * element, GstClockTime msg_time);
 
 G_END_DECLS
 

--- a/gst_bridge/include/gst_bridge/rosbasesrc.h
+++ b/gst_bridge/include/gst_bridge/rosbasesrc.h
@@ -46,6 +46,7 @@ struct _RosBaseSrc
   GstBaseSrc parent;
   gchar * node_name;
   gchar * node_namespace;
+  gchar * time_caps;
   gboolean attach_reference_timestamp;
 
   // private variables to construct the node interfaces

--- a/gst_bridge/include/gst_bridge/rosrawsink.h
+++ b/gst_bridge/include/gst_bridge/rosrawsink.h
@@ -1,0 +1,63 @@
+/* gst_bridge
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef _GST_ROSRAWSINK_H_
+#define _GST_ROSRAWSINK_H_
+
+#include <gst/base/gstbasesink.h>
+#include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesink.h>
+
+#include <gst_msgs/msg/stream_stamped_data.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_ROSRAWSINK (rosrawsink_get_type())
+#define GST_ROSRAWSINK(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_ROSRAWSINK, Rosrawsink))
+#define GST_ROSRAWSINK_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_ROSRAWSINK, RosrawsinkClass))
+#define GST_IS_ROSRAWSINK(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_ROSRAWSINK))
+#define GST_IS_ROSRAWSINK_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_ROSRAWSINK))
+
+typedef struct _Rosrawsink Rosrawsink;
+typedef struct _RosrawsinkClass RosrawsinkClass;
+
+struct _Rosrawsink
+{
+  using MsgType = gst_msgs::msg::StreamStampedData;
+
+  RosBaseSink parent;
+
+  gchar * pub_topic;
+
+  rclcpp::Publisher<MsgType>::SharedPtr pub;
+
+  uint64_t msg_seq_num;
+};
+
+struct _RosrawsinkClass
+{
+  RosBaseSinkClass parent_class;
+};
+
+GType rosrawsink_get_type(void);
+
+G_END_DECLS
+
+#endif  // _GST_ROSRAWSINK_H_

--- a/gst_bridge/include/gst_bridge/rosrawsrc.h
+++ b/gst_bridge/include/gst_bridge/rosrawsrc.h
@@ -1,0 +1,70 @@
+/* gst_bridge
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef _GST_ROSRAWSRC_H_
+#define _GST_ROSRAWSRC_H_
+
+#include <gst_bridge/gst_bridge.h>
+#include <gst_bridge/rosbasesrc.h>
+
+#include <condition_variable>  // std::condition_variable
+#include <gst_msgs/msg/stream_stamped_data.hpp>
+#include <mutex>  // std::mutex, std::unique_lock
+#include <queue>  // std::queue
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_ROSRAWSRC (rosrawsrc_get_type())
+#define GST_ROSRAWSRC(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_ROSRAWSRC, Rosrawsrc))
+#define GST_ROSRAWSRC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_ROSRAWSRC, RosrawsrcClass))
+#define GST_IS_ROSRAWSRC(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_ROSRAWSRC))
+#define GST_IS_ROSRAWSRC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_ROSRAWSRC))
+
+typedef struct _Rosrawsrc Rosrawsrc;
+typedef struct _RosrawsrcClass RosrawsrcClass;
+
+struct _Rosrawsrc
+{
+  using MsgType = gst_msgs::msg::StreamStampedData;
+
+  RosBaseSrc parent;
+  GstPad * srcpad;
+  gboolean silent;
+  gchar * sub_topic;
+  gchar * caps_string;
+
+  rclcpp::Subscription<MsgType>::SharedPtr sub;
+
+  bool started;
+  size_t msg_queue_max;
+  std::queue<MsgType::ConstSharedPtr> msg_queue;
+  std::mutex msg_queue_mtx;
+  std::condition_variable msg_queue_cv;
+};
+
+struct _RosrawsrcClass
+{
+  RosBaseSrcClass parent_class;
+};
+
+GType rosrawsrc_get_type(void);
+
+G_END_DECLS
+
+#endif  // _GST_ROSRAWSRC_H_

--- a/gst_bridge/src/rosaudiosrc.cpp
+++ b/gst_bridge/src/rosaudiosrc.cpp
@@ -461,7 +461,6 @@ static GstFlowReturn rosaudiosrc_create(
   GstBaseSrc * gst_base_src, guint64 offset, guint size, GstBuffer ** buf)
 {
   GstMapInfo info;
-  GstClockTimeDiff base_time;
   size_t length;
   GstFlowReturn ret = GST_FLOW_OK;
   GstBuffer * res_buf;
@@ -508,9 +507,8 @@ static GstFlowReturn rosaudiosrc_create(
   memcpy(info.data, msg->data.data(), length);
   gst_buffer_unmap(*buf, &info);
 
-  base_time = gst_element_get_base_time(GST_ELEMENT(src));
-  GST_BUFFER_PTS(*buf) = rclcpp::Time(msg->header.stamp).nanoseconds() -
-                         ros_base_src->ros_clock_offset - base_time;  // XXX +basetime?
+  GstClockTime msg_time = rclcpp::Time(msg->header.stamp).nanoseconds();
+  set_timestamps(buf, ros_base_src, GST_ELEMENT(src), msg_time);
 
   return GST_FLOW_OK;
 }

--- a/gst_bridge/src/rosbasesink.cpp
+++ b/gst_bridge/src/rosbasesink.cpp
@@ -32,6 +32,9 @@
 
 #include <gst_bridge/rosbasesink.h>
 
+#include <cstdint>
+#include <optional>
+
 GST_DEBUG_CATEGORY_STATIC(rosbasesink_debug_category);
 #define GST_CAT_DEFAULT rosbasesink_debug_category
 
@@ -55,12 +58,61 @@ static gboolean rosbasesink_close(RosBaseSink * sink);
   XXX provide a mechanism for ROS to provide a clock
 */
 
-enum {
-  PROP_0,
-  PROP_ROS_NAME,
-  PROP_ROS_NAMESPACE,
-  PROP_ROS_START_TIME,
-};
+enum { PROP_0, PROP_ROS_NAME, PROP_ROS_NAMESPACE, PROP_ROS_START_TIME, PROP_TIMESTAMP_MODE, PROP_TIMESTAMP_CONVERSION_MODE };
+
+std::optional<rclcpp::Time> get_reference_timestamp(GstBuffer * buf)
+{
+  GstReferenceTimestampMeta * ref_meta = gst_buffer_get_reference_timestamp_meta(buf, nullptr);
+
+  if (ref_meta) {
+    rclcpp::Time time_stamp{};
+
+    constexpr uint64_t NTP_UNIX_OFFSET_SECS = 2'208'988'800ULL;
+    constexpr uint64_t NTP_UNIX_OFFSET_NS = NTP_UNIX_OFFSET_SECS * 1'000'000'000ULL;
+
+    uint64_t corrected_ns = ref_meta->timestamp - NTP_UNIX_OFFSET_NS;
+
+    GstClockTime ntp_time = corrected_ns;
+
+    time_stamp = rclcpp::Time(static_cast<int64_t>(ntp_time));
+
+    return time_stamp;
+  }
+
+  return std::nullopt;
+}
+
+static GType gst_ros_timestamp_mode_get_type(void)
+{
+  static GType type = 0;
+  if (!type) {
+    static const GEnumValue values[] = {
+      {TIMESTAMP_MODE_ROS_OFFSET, "Ros Offset Adjusted", "ros-offset"},
+      {TIMESTAMP_MODE_REFERENCE, "Reference Timestamp (NTP)", "reference"},
+      {TIMESTAMP_MODE_PTS, "Presentation Timestamp", "pts"},
+      {0, NULL, NULL}};
+    type = g_enum_register_static("GstRosTimestampMode", values);
+  }
+  return type;
+}
+
+static GType gst_timestamp_conversion_mode_get_type(void)
+{
+  static GType type = 0;
+  if (!type) {
+    static const GEnumValue values[] = {
+      {CONVERSION_MODE_NONE, "No timestamp conversion", "none"},
+      {CONVERSION_MODE_NTP_2_UNIX, "NTP to UNIX", "ntp2unix"},
+      {0, NULL, NULL}};
+    type = g_enum_register_static("GstTimestampConversionMode", values);
+  }
+  return type;
+}
+
+rcl_clock_type_t get_clock_type_from(RosBaseSink * sink)
+{
+  return sink->node_if->clock->get_clock()->get_clock_type();
+}
 
 /* class initialization */
 
@@ -100,6 +152,22 @@ static void rosbasesink_class_init(RosBaseSinkClass * klass)
     g_param_spec_uint64(
       "ros-start-time", "ros-start-time", "ROS time (nanoseconds) of the first message", 0,
       (guint64)(-1), GST_CLOCK_TIME_NONE,
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property(
+    object_class, PROP_TIMESTAMP_MODE,
+    g_param_spec_enum(
+      "timestamp-mode", "Timestamp Mode", "How to generate ROS timestamps from incoming buffers",
+      GST_TYPE_ROS_TIMESTAMP_MODE,
+      TIMESTAMP_MODE_ROS_OFFSET,  // default
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+  
+  g_object_class_install_property(
+    object_class, PROP_TIMESTAMP_CONVERSION_MODE,
+    g_param_spec_enum(
+      "timestamp-conversion-mode", "Timestamp Conversion Mode", "Convert incoming timestamps",
+      GST_TYPE_TIMESTAMP_CONVERSION_MODE,
+      CONVERSION_MODE_NONE,  // default
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   element_class->change_state = GST_DEBUG_FUNCPTR(
@@ -149,6 +217,14 @@ void rosbasesink_set_property(
       }
       break;
 
+    case PROP_TIMESTAMP_MODE:
+      sink->timestamp_mode = (RosTimestampMode)g_value_get_enum(value);
+      break;
+
+    case PROP_TIMESTAMP_CONVERSION_MODE:
+      sink->timestamp_conversion_mode = (TimestampConversionMode)g_value_get_enum(value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
       break;
@@ -174,6 +250,14 @@ void rosbasesink_get_property(
       g_value_set_uint64(value, sink->stream_start.nanoseconds());
       // XXX this allows inspection via props,
       //      but may cause confusion because it does not show the actual prop
+      break;
+
+    case PROP_TIMESTAMP_MODE:
+      g_value_set_enum(value, sink->timestamp_mode);
+      break;
+    
+    case PROP_TIMESTAMP_CONVERSION_MODE:
+      g_value_set_enum(value, sink->timestamp_conversion_mode);
       break;
 
     default:
@@ -278,21 +362,56 @@ static gboolean rosbasesink_close(RosBaseSink * sink)
   return result;
 }
 
+int64_t ntp_to_unix(const int64_t &ntp_nsec)
+{
+  static constexpr int64_t NTP_UNIX_OFFSET_SEC = 2208988800LL;
+  return ntp_nsec - (NTP_UNIX_OFFSET_SEC * 1000000000LL);;
+}
+
 static GstFlowReturn rosbasesink_render(GstBaseSink * base_sink, GstBuffer * buf)
 {
   rclcpp::Time msg_time;
-  GstClockTimeDiff base_time;
 
   RosBaseSink * sink = GST_ROS_BASE_SINK(base_sink);
   RosBaseSinkClass * sink_class = GST_ROS_BASE_SINK_GET_CLASS(sink);
 
   GST_DEBUG_OBJECT(sink, "render");
 
-  // XXX look at the base sink clock synchronising features
-  base_time = gst_element_get_base_time(GST_ELEMENT(sink));
-  msg_time = rclcpp::Time(
-    GST_BUFFER_PTS(buf) + base_time + sink->ros_clock_offset,
-    sink->node_if->clock->get_clock()->get_clock_type());
+  switch (sink->timestamp_mode) {
+    case TIMESTAMP_MODE_REFERENCE: {
+      auto reference_time = get_reference_timestamp(buf);
+
+      if (reference_time.has_value()) {
+        msg_time = *reference_time;
+      } else {
+        if (sink->node_if)
+          RCLCPP_WARN(sink->node_if->logging->get_logger(), "no reference timestamp found");
+      }
+      break;
+    }
+    case TIMESTAMP_MODE_PTS: {
+      msg_time = rclcpp::Time(GST_BUFFER_PTS(buf), get_clock_type_from(sink));
+      break;
+    }
+    case TIMESTAMP_MODE_ROS_OFFSET: {
+      // XXX look at the base sink clock synchronising features
+      GstClockTimeDiff base_time = gst_element_get_base_time(GST_ELEMENT(sink));
+
+      msg_time = rclcpp::Time(
+        GST_BUFFER_PTS(buf) + base_time + sink->ros_clock_offset, get_clock_type_from(sink));
+    }
+  }
+
+  switch (sink->timestamp_conversion_mode) {
+    case CONVERSION_MODE_NONE:
+      // do nothing
+      break;
+    case CONVERSION_MODE_NTP_2_UNIX: {
+      // convert NTP to UNIX time
+      msg_time = rclcpp::Time(ntp_to_unix(msg_time.nanoseconds()), msg_time.get_clock_type());
+      break;
+    }
+  }
 
   if (NULL != sink_class->render) return sink_class->render(sink, buf, msg_time);
 

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -48,7 +48,7 @@ static void rosbasesrc_init(RosBaseSrc * src);
 static gboolean rosbasesrc_open(RosBaseSrc * src);
 static gboolean rosbasesrc_close(RosBaseSrc * src);
 
-static gboolean rosbasesrc_notify_thread (RosBaseSrc * src);
+static gboolean rosbasesrc_notify_thread(RosBaseSrc * src);
 
 /*
   XXX provide a mechanism for ROS to provide a clock
@@ -59,6 +59,7 @@ enum {
   PROP_ROS_NAME,
   PROP_ROS_NAMESPACE,
   PROP_ROS_START_TIME,
+  PROP_ATTACH_REFERENCE_TIMESTAMP
 };
 
 /* class initialization */
@@ -98,6 +99,13 @@ static void rosbasesrc_class_init(RosBaseSrcClass * klass)
     g_param_spec_uint64(
       "ros-start-time", "ros-start-time", "ROS time (nanoseconds) of the first message", 0,
       (guint64)(-1), GST_CLOCK_TIME_NONE,
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property(
+    object_class, PROP_ATTACH_REFERENCE_TIMESTAMP,
+    g_param_spec_boolean(
+      "attach-reference-timestamp", "Attach Reference Timestamp",
+      "Attach GstReferenceTimestampMeta to buffers for use with rtpsrc", FALSE,
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   element_class->change_state = GST_DEBUG_FUNCPTR(
@@ -145,6 +153,16 @@ void rosbasesrc_set_property(
         RCLCPP_ERROR(src->node_if->logging->get_logger(), "can't change start_time once opened");
       } else {
         src->stream_start_prop = g_value_get_uint64(value);
+      }
+      break;
+
+    case PROP_ATTACH_REFERENCE_TIMESTAMP:
+      if (src->node_if) {
+        RCLCPP_ERROR(
+          src->node_if->logging->get_logger(),
+          "can't change attach-reference-timestamp once opened");
+      } else {
+        src->attach_reference_timestamp = g_value_get_boolean(value);
       }
       break;
 
@@ -256,15 +274,14 @@ static gboolean rosbasesrc_open(RosBaseSrc * src)
   return result;
 }
 
-static gboolean rosbasesrc_notify_thread (RosBaseSrc * src)
+static gboolean rosbasesrc_notify_thread(RosBaseSrc * src)
 {
-  RosBaseSrcClass *src_class = GST_ROS_BASE_SRC_GET_CLASS (src);
+  RosBaseSrcClass * src_class = GST_ROS_BASE_SRC_GET_CLASS(src);
   using std::placeholders::_1;
 
-  GST_DEBUG_OBJECT (src, "notify_thread");
+  GST_DEBUG_OBJECT(src, "notify_thread");
 
-  if(src_class->notify_thread)
-    src_class->notify_thread(src);
+  if (src_class->notify_thread) src_class->notify_thread(src);
 
   return TRUE;
 }
@@ -287,4 +304,30 @@ static gboolean rosbasesrc_close(RosBaseSrc * src)
   // if the node doesn't exist, hang onto the node_if
 
   return result;
+}
+
+void set_timestamps(
+  GstBuffer ** buffer, RosBaseSrc * src, GstElement * element, GstClockTime msg_time)
+{
+  GstClockTime base_time = gst_element_get_base_time(element);
+  GstClockTime stream_pts = msg_time - src->ros_clock_offset - base_time;
+  GST_BUFFER_PTS(*buffer) = stream_pts;
+
+  if (src->attach_reference_timestamp) {
+    GstCaps * caps = gst_caps_new_empty_simple("timestamp/x-unix");
+
+    if (!caps || !GST_IS_CAPS(caps)) {
+      GST_WARNING_OBJECT(src, "Could not attach reference timestamp meta: no valid caps");
+      return;
+    }
+
+    GstReferenceTimestampMeta * ref_ts_meta =
+      gst_buffer_add_reference_timestamp_meta(*buffer, caps, msg_time, GST_CLOCK_TIME_NONE);
+
+    if (!ref_ts_meta) {
+      GST_WARNING_OBJECT(src, "Failed to add reference timestamp metadata");
+    }
+
+    gst_caps_unref(caps);  // prevent memory leak
+  }
 }

--- a/gst_bridge/src/rosbasesrc.cpp
+++ b/gst_bridge/src/rosbasesrc.cpp
@@ -59,7 +59,8 @@ enum {
   PROP_ROS_NAME,
   PROP_ROS_NAMESPACE,
   PROP_ROS_START_TIME,
-  PROP_ATTACH_REFERENCE_TIMESTAMP
+  PROP_ATTACH_REFERENCE_TIMESTAMP,
+  PROP_TIME_CAPS
 };
 
 /* class initialization */
@@ -102,6 +103,13 @@ static void rosbasesrc_class_init(RosBaseSrcClass * klass)
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property(
+    object_class, PROP_TIME_CAPS,
+    g_param_spec_string(
+      "time-caps", "Time Caps", "Output time caps (e.g., timestamp/x-unix)",
+      "timestamp/x-rostime",  // default
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property(
     object_class, PROP_ATTACH_REFERENCE_TIMESTAMP,
     g_param_spec_boolean(
       "attach-reference-timestamp", "Attach Reference Timestamp",
@@ -119,6 +127,8 @@ static void rosbasesrc_init(RosBaseSrc * src)
   src->node_name = g_strdup("ros_base_src_node");
   src->node_namespace = g_strdup("");
   src->stream_start_prop = GST_CLOCK_TIME_NONE;
+  src->time_caps = g_strdup("timestamp/x-rostime");
+  src->attach_reference_timestamp = false;
 }
 
 void rosbasesrc_set_property(
@@ -126,7 +136,7 @@ void rosbasesrc_set_property(
 {
   RosBaseSrc * src = GST_ROS_BASE_SRC(object);
 
-  GST_DEBUG_OBJECT(src, "set_property");
+  GST_DEBUG_OBJECT(src, "set_property called, id=%d, name=%s", property_id, pspec->name);
 
   switch (property_id) {
     case PROP_ROS_NAME:
@@ -154,6 +164,11 @@ void rosbasesrc_set_property(
       } else {
         src->stream_start_prop = g_value_get_uint64(value);
       }
+      break;
+
+    case PROP_TIME_CAPS:
+      g_free(src->time_caps);
+      src->time_caps = g_value_dup_string(value);
       break;
 
     case PROP_ATTACH_REFERENCE_TIMESTAMP:
@@ -191,6 +206,10 @@ void rosbasesrc_get_property(
       g_value_set_uint64(value, src->stream_start.nanoseconds());
       // XXX this allows inspection via props,
       //      but may cause confusion because it does not show the actual prop
+      break;
+
+    case PROP_TIME_CAPS:
+      g_value_set_string(value, src->time_caps);
       break;
 
     default:
@@ -314,7 +333,7 @@ void set_timestamps(
   GST_BUFFER_PTS(*buffer) = stream_pts;
 
   if (src->attach_reference_timestamp) {
-    GstCaps * caps = gst_caps_new_empty_simple("timestamp/x-unix");
+    GstCaps * caps = gst_caps_new_empty_simple(src->time_caps);
 
     if (!caps || !GST_IS_CAPS(caps)) {
       GST_WARNING_OBJECT(src, "Could not attach reference timestamp meta: no valid caps");

--- a/gst_bridge/src/rosgstbridgeplugin.cpp
+++ b/gst_bridge/src/rosgstbridgeplugin.cpp
@@ -25,6 +25,8 @@
 #include <gst_bridge/rosaudiosrc.h>
 #include <gst_bridge/rosimagesink.h>
 #include <gst_bridge/rosimagesrc.h>
+#include <gst_bridge/rosrawsink.h>
+#include <gst_bridge/rosrawsrc.h>
 #include <gst_bridge/rostextsink.h>
 #include <gst_bridge/rostextsrc.h>
 
@@ -39,11 +41,15 @@ static gboolean plugin_init(GstPlugin * plugin)
 
   gst_element_register(plugin, "rostextsink", GST_RANK_NONE, GST_TYPE_ROSTEXTSINK);
 
+  gst_element_register(plugin, "rosrawsink", GST_RANK_NONE, GST_TYPE_ROSRAWSINK);
+
   gst_element_register(plugin, "rosaudiosrc", GST_RANK_NONE, GST_TYPE_ROSAUDIOSRC);
 
   gst_element_register(plugin, "rosimagesrc", GST_RANK_NONE, GST_TYPE_ROSIMAGESRC);
 
   gst_element_register(plugin, "rostextsrc", GST_RANK_NONE, GST_TYPE_ROSTEXTSRC);
+
+  gst_element_register(plugin, "rosrawsrc", GST_RANK_NONE, GST_TYPE_ROSRAWSRC);
 
   return true;
 }

--- a/gst_bridge/src/rosimagesrc.cpp
+++ b/gst_bridge/src/rosimagesrc.cpp
@@ -134,8 +134,7 @@ static void rosimagesrc_class_init(RosimagesrcClass * klass)
     GST_DEBUG_FUNCPTR(rosimagesrc_open);  //let the base sink know how we register publishers
   ros_base_src_class->close =
     GST_DEBUG_FUNCPTR(rosimagesrc_close);  //let the base sink know how we destroy publishers
-  ros_base_src_class->notify_thread =
-    GST_DEBUG_FUNCPTR(rosimagesrc_notify_thread);
+  ros_base_src_class->notify_thread = GST_DEBUG_FUNCPTR(rosimagesrc_notify_thread);
 
   basesrc_class->create = GST_DEBUG_FUNCPTR(rosimagesrc_create);
   basesrc_class->get_caps = GST_DEBUG_FUNCPTR(rosimagesrc_getcaps);  //return caps within the filter
@@ -145,7 +144,6 @@ static void rosimagesrc_class_init(RosimagesrcClass * klass)
   //basesrc_class->negotiate = GST_DEBUG_FUNCPTR (rosimagesrc_negotiate);  //start figuring out caps and allocators
   //basesrc_class->event = GST_DEBUG_FUNCPTR (rosimagesrc_event);  //flush events can cause discontinuities (flags exist in buffers)
   //basesrc_class->get_times = GST_DEBUG_FUNCPTR (rosimagesrc_get_times); //asks us for start and stop times (?)
-
 }
 
 static void rosimagesrc_init(Rosimagesrc * src)
@@ -337,11 +335,11 @@ static gboolean rosimagesrc_close(RosBaseSrc * ros_base_src)
   return TRUE;
 }
 
-static gboolean rosimagesrc_notify_thread (RosBaseSrc * ros_base_src)
+static gboolean rosimagesrc_notify_thread(RosBaseSrc * ros_base_src)
 {
-  Rosimagesrc *src = GST_ROSIMAGESRC (ros_base_src);
+  Rosimagesrc * src = GST_ROSIMAGESRC(ros_base_src);
 
-  GST_DEBUG_OBJECT (src, "notify_thread");
+  GST_DEBUG_OBJECT(src, "notify_thread");
 
   // notify any waiting threads
   src->msg_queue_cv.notify_all();
@@ -476,7 +474,6 @@ static GstFlowReturn rosimagesrc_create(
   Rosimagesrc * src = GST_ROSIMAGESRC(base_src);
 
   GstMapInfo info;
-  GstClockTimeDiff base_time;
   size_t length;
   GstFlowReturn ret = GST_FLOW_OK;
   GstBuffer * res_buf;
@@ -490,14 +487,13 @@ static GstFlowReturn rosimagesrc_create(
   }
 
   auto msg = rosimagesrc_wait_for_msg(src);
-  if (!msg)
-  {
-    GST_DEBUG_OBJECT (src, "no message to create buffer from");
+  if (!msg) {
+    GST_DEBUG_OBJECT(src, "no message to create buffer from");
     return GST_FLOW_ERROR;
   } else {
-    { //scope the mutex lock
+    {  //scope the mutex lock
       std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
-      src->msg_queue.clear();   // XXX we can stop dropping the first message during preroll now
+      src->msg_queue.clear();  // XXX we can stop dropping the first message during preroll now
     }
   }
 
@@ -525,9 +521,8 @@ static GstFlowReturn rosimagesrc_create(
   memcpy(info.data, msg->data.data(), length);
   gst_buffer_unmap(*buf, &info);
 
-  base_time = gst_element_get_base_time(GST_ELEMENT(src));
-  GST_BUFFER_PTS(*buf) =
-    rclcpp::Time(msg->header.stamp).nanoseconds() - ros_base_src->ros_clock_offset - base_time;
+  GstClockTime msg_time = rclcpp::Time(msg->header.stamp).nanoseconds();
+  set_timestamps(buf, ros_base_src, GST_ELEMENT(src), msg_time);
 
   return ret;
 }
@@ -581,8 +576,7 @@ static sensor_msgs::msg::Image::ConstSharedPtr rosimagesrc_wait_for_msg(Rosimage
 
   std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
   src->msg_queue_cv.wait(lck);
-  if (src->msg_queue.empty())
-  {
+  if (src->msg_queue.empty()) {
     // the wait was interrupted
     return sensor_msgs::msg::Image::ConstSharedPtr();
   }

--- a/gst_bridge/src/rosrawsink.cpp
+++ b/gst_bridge/src/rosrawsink.cpp
@@ -1,0 +1,165 @@
+/* gst_bridge
+ * Copyright (C) 2020-2021 Brett Downing <brettrd@brettrd.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+/**
+ * SECTION:element-gstrosrawsink
+ *
+ * The rosrawsink element, pipe raw data into ROS2.
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * gst-launch-1.0 filesrc location=/bin/ls ! application/octet-stream ! rosrawsink
+ * ]|
+ * </refsect2>
+ */
+#include <gst_bridge/rosrawsink.h>
+
+#include <memory>
+
+GST_DEBUG_CATEGORY_STATIC(rosrawsink_debug_category);
+#define GST_CAT_DEFAULT rosrawsink_debug_category
+
+static void rosrawsink_set_property(
+  GObject * object, guint property_id, const GValue * value, GParamSpec * pspec);
+static void rosrawsink_get_property(
+  GObject * object, guint property_id, GValue * value, GParamSpec * pspec);
+static void rosrawsink_init(Rosrawsink * sink);
+static gboolean rosrawsink_open(RosBaseSink * ros_base_sink);
+static gboolean rosrawsink_close(RosBaseSink * ros_base_sink);
+static GstFlowReturn rosrawsink_render(
+  RosBaseSink * sink, GstBuffer * buffer, rclcpp::Time msg_time);
+
+enum { PROP_0, PROP_ROS_TOPIC };
+
+static GstStaticPadTemplate rosrawsink_sink_template = GST_STATIC_PAD_TEMPLATE(
+  "sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS("application/x-onvif-metadata"));
+
+G_DEFINE_TYPE_WITH_CODE(
+  Rosrawsink, rosrawsink, GST_TYPE_ROS_BASE_SINK,
+  GST_DEBUG_CATEGORY_INIT(rosrawsink_debug_category, "rosrawsink", 0, "ROS raw sink debug"))
+
+static void rosrawsink_class_init(RosrawsinkClass * klass)
+{
+  GObjectClass * object_class = G_OBJECT_CLASS(klass);
+  GstElementClass * element_class = GST_ELEMENT_CLASS(klass);
+  RosBaseSinkClass * ros_base_sink_class = GST_ROS_BASE_SINK_CLASS(klass);
+
+  object_class->set_property = rosrawsink_set_property;
+  object_class->get_property = rosrawsink_get_property;
+
+  gst_element_class_add_static_pad_template(element_class, &rosrawsink_sink_template);
+
+  gst_element_class_set_static_metadata(
+    element_class, "rosrawsink", "Sink", "Publishes raw byte data to ROS",
+    "Guilherme Rodrigues <guilherme.rodrigues@ait.ac.at>");
+
+  g_object_class_install_property(
+    object_class, PROP_ROS_TOPIC,
+    g_param_spec_string(
+      "ros-topic", "ROS Topic", "ROS topic to publish raw data on", "raw_data",
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  ros_base_sink_class->open = GST_DEBUG_FUNCPTR(rosrawsink_open);
+  ros_base_sink_class->close = GST_DEBUG_FUNCPTR(rosrawsink_close);
+  ros_base_sink_class->render = GST_DEBUG_FUNCPTR(rosrawsink_render);
+}
+
+static void rosrawsink_init(Rosrawsink * sink)
+{
+  RosBaseSink * ros_base_sink = GST_ROS_BASE_SINK(sink);
+  ros_base_sink->node_name = g_strdup("gst_raw_sink_node");
+  sink->pub_topic = g_strdup("gst_raw_pub");
+}
+
+static void rosrawsink_set_property(
+  GObject * object, guint property_id, const GValue * value, GParamSpec * pspec)
+{
+  Rosrawsink * sink = GST_ROSRAWSINK(object);
+  RosBaseSink * ros_base_sink = GST_ROS_BASE_SINK(object);
+
+  switch (property_id) {
+    case PROP_ROS_TOPIC:
+      if (ros_base_sink->node_if) {
+        RCLCPP_ERROR(
+          ros_base_sink->node_if->logging->get_logger(), "Can't change topic name after startup");
+      } else {
+        g_free(sink->pub_topic);
+        sink->pub_topic = g_value_dup_string(value);
+      }
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+      break;
+  }
+}
+
+static void rosrawsink_get_property(
+  GObject * object, guint property_id, GValue * value, GParamSpec * pspec)
+{
+  Rosrawsink * sink = GST_ROSRAWSINK(object);
+
+  switch (property_id) {
+    case PROP_ROS_TOPIC:
+      g_value_set_string(value, sink->pub_topic);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+      break;
+  }
+}
+
+static gboolean rosrawsink_open(RosBaseSink * ros_base_sink)
+{
+  GST_DEBUG_OBJECT(ros_base_sink, "open");
+
+  Rosrawsink * sink = GST_ROSRAWSINK(ros_base_sink);
+  rclcpp::QoS qos = rclcpp::SensorDataQoS();
+
+  sink->pub = rclcpp::create_publisher<Rosrawsink::MsgType>(
+    ros_base_sink->node_if->parameters, ros_base_sink->node_if->topics, sink->pub_topic, qos);
+
+  return TRUE;
+}
+
+static gboolean rosrawsink_close(RosBaseSink * ros_base_sink)
+{
+  Rosrawsink * sink = GST_ROSRAWSINK(ros_base_sink);
+  GST_DEBUG_OBJECT(sink, "close");
+  sink->pub.reset();
+  return TRUE;
+}
+
+static GstFlowReturn rosrawsink_render(RosBaseSink * ros_base_sink, GstBuffer * buf, rclcpp::Time msg_time)
+{
+  Rosrawsink * sink = GST_ROSRAWSINK(ros_base_sink);
+  Rosrawsink::MsgType msg;
+  GstMapInfo info;
+
+  if (!gst_buffer_map(buf, &info, GST_MAP_READ)) {
+    GST_ERROR_OBJECT(sink, "Failed to map GstBuffer");
+    return GST_FLOW_ERROR;
+  }
+
+  msg.header.stamp = msg_time;
+  msg.data = std::vector<uint8_t>(info.data, info.data + info.size);
+  gst_buffer_unmap(buf, &info);
+
+  sink->pub->publish(msg);
+
+  return GST_FLOW_OK;
+}

--- a/gst_bridge/src/rosrawsrc.cpp
+++ b/gst_bridge/src/rosrawsrc.cpp
@@ -84,7 +84,7 @@ static void rosrawsrc_class_init(RosrawsrcClass * klass)
     object_class, PROP_CAPS,
     g_param_spec_string(
       "caps", "Caps", "Output caps (e.g., application/x-onvif-metadata)",
-      "application/x-onvif-metadata",  // default
+      "ANY",  // default
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   ros_base_src_class->open = GST_DEBUG_FUNCPTR(rosrawsrc_open);
@@ -103,7 +103,7 @@ static void rosrawsrc_init(Rosrawsrc * src)
 
   src->silent = FALSE;
   src->sub_topic = g_strdup("raw");
-  src->caps_string = g_strdup("application/x-onvif-metadata");  // Default caps
+  src->caps_string = g_strdup("ANY");
 
   src->started = false;
   src->msg_queue_max = 1;

--- a/gst_bridge/src/rosrawsrc.cpp
+++ b/gst_bridge/src/rosrawsrc.cpp
@@ -17,79 +17,58 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-/**
- * SECTION:element-gstrostextsrc
- *
- * The rostextsrc element subscribes to a ROS2 topic and feeds text into a pipeline.
- *
- * <refsect2>
- * <title>Example launch line</title>
- * |[
- * gst-launch-1.0 -v rostextsrc topic="/string" ! txt. videotestsrc ! textoverlay name=txt ! autovideosink
- * ]|
- * Subscribe to /string topic and overlay on test video.
- * </refsect2>
- */
+#include <gst_bridge/rosrawsrc.h>
 
-#include <gst_bridge/rostextsrc.h>
+GST_DEBUG_CATEGORY_STATIC(rosrawsrc_debug_category);
+#define GST_CAT_DEFAULT rosrawsrc_debug_category
 
-GST_DEBUG_CATEGORY_STATIC(rostextsrc_debug_category);
-#define GST_CAT_DEFAULT rostextsrc_debug_category
-
-/* prototypes */
-
-static void rostextsrc_set_property(
+static void rosrawsrc_set_property(
   GObject * object, guint prop_id, const GValue * value, GParamSpec * pspec);
-static void rostextsrc_get_property(
+static void rosrawsrc_get_property(
   GObject * object, guint prop_id, GValue * value, GParamSpec * pspec);
 
-static void rostextsrc_init(Rostextsrc * src);
-
-static gboolean rostextsrc_open(RosBaseSrc * ros_base_src);
-static gboolean rostextsrc_close(RosBaseSrc * ros_base_src);
-
-static GstFlowReturn rostextsrc_create(
+static void rosrawsrc_init(Rosrawsrc * src);
+static gboolean rosrawsrc_open(RosBaseSrc * ros_base_src);
+static gboolean rosrawsrc_close(RosBaseSrc * ros_base_src);
+static GstFlowReturn rosrawsrc_create(
   GstBaseSrc * base_src, guint64 offset, guint size, GstBuffer ** buf);
-static gboolean rostextsrc_query(GstBaseSrc * base_src, GstQuery * query);
 
-static void rostextsrc_sub_cb(Rostextsrc * src, std_msgs::msg::String::ConstSharedPtr msg);
-static std_msgs::msg::String::ConstSharedPtr rostextsrc_wait_for_msg(Rostextsrc * src);
+static gboolean rosrawsrc_query(GstBaseSrc * base_src, GstQuery * query);
+static void rosrawsrc_sub_cb(Rosrawsrc * src, Rosrawsrc::MsgType::ConstSharedPtr msg);
+static Rosrawsrc::MsgType::ConstSharedPtr rosrawsrc_wait_for_msg(Rosrawsrc * src);
 
 enum {
   PROP_0,
   PROP_SILENT,
   PROP_ROS_TOPIC,
+  PROP_CAPS,
 };
 
-/* pad templates */
-
-static GstStaticPadTemplate rostextsrc_src_template =
-  GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS(ROS_TEXT_MSG_CAPS));
-
-/* class initialization */
+static GstStaticPadTemplate rosrawsrc_src_template = GST_STATIC_PAD_TEMPLATE(
+  "src", GST_PAD_SRC, GST_PAD_ALWAYS,
+  GST_STATIC_CAPS("application/x-onvif-metadata, format=(string)xml, type=(string)metadata"));
 
 G_DEFINE_TYPE_WITH_CODE(
-  Rostextsrc, rostextsrc, GST_TYPE_ROS_BASE_SRC,
-  GST_DEBUG_CATEGORY_INIT(
-    rostextsrc_debug_category, "rostextsrc", 0, "debug category for rostextsrc element"))
+  Rosrawsrc, rosrawsrc, GST_TYPE_ROS_BASE_SRC,
+  GST_DEBUG_CATEGORY_INIT(rosrawsrc_debug_category, "rosrawsrc", 0, "debug category for rosrawsrc"))
 
-static void rostextsrc_class_init(RostextsrcClass * klass)
+static void rosrawsrc_class_init(RosrawsrcClass * klass)
 {
   GObjectClass * object_class = G_OBJECT_CLASS(klass);
   GstElementClass * element_class = GST_ELEMENT_CLASS(klass);
   GstBaseSrcClass * basesrc_class = GST_BASE_SRC_CLASS(klass);
   RosBaseSrcClass * ros_base_src_class = GST_ROS_BASE_SRC_CLASS(klass);
 
-  object_class->set_property = rostextsrc_set_property;
-  object_class->get_property = rostextsrc_get_property;
+  object_class->set_property = rosrawsrc_set_property;
+  object_class->get_property = rosrawsrc_get_property;
 
   gst_element_class_add_pad_template(
-    element_class, gst_static_pad_template_get(&rostextsrc_src_template));
+    element_class, gst_static_pad_template_get(&rosrawsrc_src_template));
 
   gst_element_class_set_static_metadata(
-    element_class, "rostextsrc", "Source/Text",
-    "a gstreamer source that transports ROS strings over gstreamer",
-    "Clyde McQueen <clyde@mcqueen.net>");
+    element_class, "rosrawsrc", "Source/Binary",
+    "A GStreamer source that transports raw byte data over gstreamer",
+    "Guilherme Rodrigues <guilherme.rodrigues@ait.ac.at>");
 
   g_object_class_install_property(
     object_class, PROP_SILENT,
@@ -98,43 +77,54 @@ static void rostextsrc_class_init(RostextsrcClass * klass)
   g_object_class_install_property(
     object_class, PROP_ROS_TOPIC,
     g_param_spec_string(
-      "topic", "Topic", "ROS topic to subscribe to", "string",
+      "ros-topic", "Topic", "ROS topic to subscribe to", "raw",
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-  ros_base_src_class->open =
-    GST_DEBUG_FUNCPTR(rostextsrc_open);  //let the base sink know how we register publishers
-  ros_base_src_class->close =
-    GST_DEBUG_FUNCPTR(rostextsrc_close);  //let the base sink know how we destroy publishers
+  g_object_class_install_property(
+    object_class, PROP_CAPS,
+    g_param_spec_string(
+      "caps", "Caps", "Output caps (e.g., application/x-onvif-metadata)",
+      "application/x-onvif-metadata",  // default
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-  basesrc_class->create = GST_DEBUG_FUNCPTR(rostextsrc_create);
-  basesrc_class->query = GST_DEBUG_FUNCPTR(rostextsrc_query);  //set the scheduling modes
+  ros_base_src_class->open = GST_DEBUG_FUNCPTR(rosrawsrc_open);
+  ros_base_src_class->close = GST_DEBUG_FUNCPTR(rosrawsrc_close);
+  basesrc_class->create = GST_DEBUG_FUNCPTR(rosrawsrc_create);
+
+  basesrc_class->query = GST_DEBUG_FUNCPTR(rosrawsrc_query);  //set the scheduling modes
 }
 
-static void rostextsrc_init(Rostextsrc * src)
+static void rosrawsrc_init(Rosrawsrc * src)
 {
-  RosBaseSrc * ros_base_src GST_ROS_BASE_SRC(src);
-  ros_base_src->node_name = g_strdup("gst_text_src_node");
+  GST_DEBUG_OBJECT(src, "init");
+
+  RosBaseSrc * ros_base_src = GST_ROS_BASE_SRC(src);
+  ros_base_src->node_name = g_strdup("gst_raw_src_node");
+
   src->silent = FALSE;
-  src->sub_topic = g_strdup("string");
+  src->sub_topic = g_strdup("raw");
+  src->caps_string = g_strdup("application/x-onvif-metadata");  // Default caps
 
+  src->started = false;
   src->msg_queue_max = 1;
-  // XXX why does queue segfault without expicit construction?
-  src->msg_queue = std::queue<std_msgs::msg::String::ConstSharedPtr>();
+  src->msg_queue = std::queue<Rosrawsrc::MsgType::ConstSharedPtr>();
 
-  /* configure basesrc to be a live source */
+  // Configure base src behavior
   gst_base_src_set_live(GST_BASE_SRC(src), TRUE);
-  /* make basesrc output a segment in time */
   gst_base_src_set_format(GST_BASE_SRC(src), GST_FORMAT_TIME);
-  /* make basesrc set timestamps on outgoing buffers based on the running_time
-   * when they were captured */
   gst_base_src_set_do_timestamp(GST_BASE_SRC(src), TRUE);
+
+  src->srcpad = gst_element_get_static_pad(GST_ELEMENT(src), "src");
+
+  GST_DEBUG_OBJECT(
+    src, "rosrawsrc initialized with topic '%s' and caps '%s'", src->sub_topic, src->caps_string);
 }
 
-static void rostextsrc_set_property(
+static void rosrawsrc_set_property(
   GObject * object, guint prop_id, const GValue * value, GParamSpec * pspec)
 {
   RosBaseSrc * ros_base_src = GST_ROS_BASE_SRC(object);
-  Rostextsrc * src = GST_ROSTEXTSRC(object);
+  Rosrawsrc * src = GST_ROSRAWSRC(object);
 
   switch (prop_id) {
     case PROP_SILENT:
@@ -151,16 +141,21 @@ static void rostextsrc_set_property(
       }
       break;
 
+    case PROP_CAPS:
+      g_free(src->caps_string);
+      src->caps_string = g_value_dup_string(value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
       break;
   }
 }
 
-static void rostextsrc_get_property(
+static void rosrawsrc_get_property(
   GObject * object, guint prop_id, GValue * value, GParamSpec * pspec)
 {
-  Rostextsrc * src = GST_ROSTEXTSRC(object);
+  Rosrawsrc * src = GST_ROSRAWSRC(object);
 
   switch (prop_id) {
     case PROP_SILENT:
@@ -171,6 +166,10 @@ static void rostextsrc_get_property(
       g_value_set_string(value, src->sub_topic);
       break;
 
+    case PROP_CAPS:
+      g_value_set_string(value, src->caps_string);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
       break;
@@ -178,9 +177,9 @@ static void rostextsrc_get_property(
 }
 
 /* open the subscription with given specs */
-static gboolean rostextsrc_open(RosBaseSrc * ros_base_src)
+static gboolean rosrawsrc_open(RosBaseSrc * ros_base_src)
 {
-  Rostextsrc * src = GST_ROSTEXTSRC(ros_base_src);
+  Rosrawsrc * src = GST_ROSRAWSRC(ros_base_src);
 
   using std::placeholders::_1;
 
@@ -188,25 +187,23 @@ static gboolean rostextsrc_open(RosBaseSrc * ros_base_src)
 
   // ROS can't cope with some forms of std::bind being passed as subscriber callbacks,
   // lambdas seem to be the preferred case for these instances
-  auto cb = [src](std_msgs::msg::String::ConstSharedPtr msg) { rostextsrc_sub_cb(src, msg); };
+  auto cb = [src](Rosrawsrc::MsgType::ConstSharedPtr msg) { rosrawsrc_sub_cb(src, msg); };
   rclcpp::QoS qos = rclcpp::SensorDataQoS();  //XXX add a parameter for overrides
 
-  src->sub = rclcpp::create_subscription<std_msgs::msg::String>(
+  GST_DEBUG_OBJECT(src, "subscribing to topic '%s'", src->sub_topic);
+
+  src->sub = rclcpp::create_subscription<Rosrawsrc::MsgType>(
     ros_base_src->node_if->parameters, ros_base_src->node_if->topics, src->sub_topic, qos, cb);
 
   return TRUE;
 }
 
-/* close the device */
-static gboolean rostextsrc_close(RosBaseSrc * ros_base_src)
+static gboolean rosrawsrc_close(RosBaseSrc * ros_base_src)
 {
-  Rostextsrc * src = GST_ROSTEXTSRC(ros_base_src);
+  Rosrawsrc * src = GST_ROSRAWSRC(ros_base_src);
 
   GST_DEBUG_OBJECT(src, "close");
-
-  //XXX dereference is as close as foxy gets to unsubscribe
   src->sub.reset();
-  //empty the queue
   std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
   while (!src->msg_queue.empty()) {
     src->msg_queue.pop();
@@ -215,11 +212,9 @@ static gboolean rostextsrc_close(RosBaseSrc * ros_base_src)
   return TRUE;
 }
 
-static gboolean rostextsrc_query(GstBaseSrc * base_src, GstQuery * query)
+static gboolean rosrawsrc_query(GstBaseSrc * base_src, GstQuery * query)
 {
   gboolean ret;
-
-  //Rostextsrc *src = GST_ROSTEXTSRC (base_src);
 
   switch (GST_QUERY_TYPE(query)) {
     case GST_QUERY_SCHEDULING: {
@@ -232,7 +227,7 @@ static gboolean rostextsrc_query(GstBaseSrc * base_src, GstQuery * query)
       break;
     }
     default:
-      ret = GST_BASE_SRC_CLASS(rostextsrc_parent_class)->query(base_src, query);
+      ret = GST_BASE_SRC_CLASS(rosrawsrc_parent_class)->query(base_src, query);
       break;
   }
   return ret;
@@ -243,26 +238,47 @@ static gboolean rostextsrc_query(GstBaseSrc * base_src, GstQuery * query)
  * Also update frame_id and encoding
  * Error if the number of channels or encoding changes at runtime
  */
-static GstFlowReturn rostextsrc_create(
+static GstFlowReturn rosrawsrc_create(
   GstBaseSrc * base_src, guint64 offset, guint size, GstBuffer ** buf)
 {
   RosBaseSrc * ros_base_src = GST_ROS_BASE_SRC(base_src);
-  Rostextsrc * src = GST_ROSTEXTSRC(base_src);
+  Rosrawsrc * src = GST_ROSRAWSRC(base_src);
 
   GstMapInfo info;
   size_t length;
   GstFlowReturn ret = GST_FLOW_OK;
   GstBuffer * res_buf;
 
-  GST_DEBUG_OBJECT(src, "create");
+  if (!src->started) {
+    if (!GST_IS_PAD(src->srcpad)) {
+      GST_ERROR_OBJECT(src, "srcpad is invalid, cannot create stream ID");
+      return GST_FLOW_ERROR;
+    }
 
-  if (!ros_base_src->node_if) {
-    GST_DEBUG_OBJECT(src, "ros text creating buffer before node init");
-  } else if (false /* src->msg_init */) {
-    GST_DEBUG_OBJECT(src, "ros text creating buffer before receiving first message");
+    gchar * stream_id = gst_pad_create_stream_id(src->srcpad, GST_ELEMENT(src), "rosraw");
+    if (!stream_id) {
+      GST_ERROR_OBJECT(src, "Failed to create stream ID");
+      return GST_FLOW_ERROR;
+    }
+
+    GstEvent * event = gst_event_new_stream_start(stream_id);
+    g_free(stream_id);
+
+    if (!gst_pad_push_event(GST_BASE_SRC_PAD(src), event)) {
+      GST_ERROR_OBJECT(src, "Failed to push stream-start event");
+      return GST_FLOW_ERROR;
+    }
+
+    src->started = true;
   }
 
-  auto msg = rostextsrc_wait_for_msg(src);
+  if (!ros_base_src->node_if) {
+    GST_DEBUG_OBJECT(src, "ros raw src creating buffer before node init");
+  } else if (false /* src->msg_init */) {
+    GST_DEBUG_OBJECT(src, "ros raw src creating buffer before receiving first message");
+  }
+
+  auto msg = rosrawsrc_wait_for_msg(src);
   {  //scope the mutex lock
     std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
     src->msg_queue.pop();  // XXX we can stop dropping the first message during preroll now
@@ -275,9 +291,10 @@ static GstFlowReturn rostextsrc_create(
     /* downstream did not provide us with a buffer to fill, allocate one
      * ourselves
      * XXX pass the vector memory on directly */
-    ret = GST_BASE_SRC_CLASS(rostextsrc_parent_class)->alloc(base_src, offset, length, &res_buf);
-    if (G_UNLIKELY(ret != GST_FLOW_OK))
+    ret = GST_BASE_SRC_CLASS(rosrawsrc_parent_class)->alloc(base_src, offset, length, &res_buf);
+    if (G_UNLIKELY(ret != GST_FLOW_OK)) {
       GST_DEBUG_OBJECT(src, "Failed to allocate buffer of %lu bytes", length);
+    }
     *buf = res_buf;
     size = length;
   } else {
@@ -294,31 +311,20 @@ static GstFlowReturn rostextsrc_create(
   memcpy(info.data, msg->data.data(), length);
   gst_buffer_unmap(*buf, &info);
 
-  // String message does not have a header, use node->now() TODO call now() in the cb and save in the queue
-  // GST_BUFFER_PTS (*buf) = rclcpp::Time(msg->header.stamp).nanoseconds() - ros_base_src->ros_clock_offset - base_time;
-  GstClockTime msg_time =
-    rclcpp::Time(ros_base_src->node_if->clock->get_clock()->now()).nanoseconds();
+  GstClockTime msg_time = rclcpp::Time(msg->header.stamp).nanoseconds();
   set_timestamps(buf, ros_base_src, GST_ELEMENT(src), msg_time);
 
   // TODO explore configurable message types
-  //GST_BUFFER_DURATION (*buf) = GST_CLOCK_TIME_NONE;
+  // GST_BUFFER_DURATION(*buf) = GST_CLOCK_TIME_NONE;
   //GST_BUFFER_DURATION (*buf) = 0;
   GST_BUFFER_DURATION(*buf) = 1000000000L;
-
-  GST_DEBUG_OBJECT(
-    src, "Sending text '%s', %" GST_TIME_FORMAT " + %" GST_TIME_FORMAT, msg->data.c_str(),
-    GST_TIME_ARGS(GST_BUFFER_PTS(*buf)), GST_TIME_ARGS(GST_BUFFER_DURATION(*buf)));
 
   return ret;
 }
 
-static void rostextsrc_sub_cb(Rostextsrc * src, std_msgs::msg::String::ConstSharedPtr msg)
+static void rosrawsrc_sub_cb(Rosrawsrc * src, Rosrawsrc::MsgType::ConstSharedPtr msg)
 {
   RosBaseSrc * ros_base_src = GST_ROS_BASE_SRC(src);
-  GST_DEBUG_OBJECT(src, "ros cb called");
-  RCLCPP_DEBUG(
-    ros_base_src->node_if->logging->get_logger(), "ros cb called with %s", msg->data.c_str());
-
   std::unique_lock<std::mutex> lck(src->msg_queue_mtx);
   src->msg_queue.push(msg);
   while (src->msg_queue.size() > src->msg_queue_max) {
@@ -328,7 +334,7 @@ static void rostextsrc_sub_cb(Rostextsrc * src, std_msgs::msg::String::ConstShar
   src->msg_queue_cv.notify_one();
 }
 
-static std_msgs::msg::String::ConstSharedPtr rostextsrc_wait_for_msg(Rostextsrc * src)
+static Rosrawsrc::MsgType::ConstSharedPtr rosrawsrc_wait_for_msg(Rosrawsrc * src)
 {
   //RosBaseSrc *ros_base_src = GST_ROS_BASE_SRC (src);
 

--- a/gst_msgs/CMakeLists.txt
+++ b/gst_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ set(msg_files
   "msg/ClockObservation.msg"
   "msg/MultifilesinkEvent.msg"
   "msg/MetaMark.msg"
+  "msg/StreamStampedData.msg"
   "srv/Seek.srv"
 )
 

--- a/gst_msgs/msg/StreamStampedData.msg
+++ b/gst_msgs/msg/StreamStampedData.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header 
+
+uint8[] data          # Raw data


### PR DESCRIPTION
Timestamp propagation (configurable) + raw metadata src/sink (`rosrawsrc`, `rosrawsink`) + base-class timestamping refactor.

## TL;DR

* New **configurable timestamping** on sinks:
  * `timestamp-mode` = `ros-offset` (default) | `reference` | `pts`
  * `timestamp-conversion-mode` = `none` (default) | `ntp2unix`
* New **raw metadata** bridge:
  * `rosrawsrc` and `rosrawsink` using `gst_msgs/StreamStampedData`
* Sources (`rosimagesrc`, `rostextsrc`) now stamp buffers via a **shared helper** that can also attach **reference timestamp meta** (`attach-reference-timestamp`). 
* Sources allow overriding the caps of timestamps for the **reference-timestamp metadata** via `time-caps`

## Motivation

1. **End-to-end timestamp propagation.** Depending on pipeline topology (RTSP/ONVIF, local sources, or synthetic inputs), the authoritative timestamp may live in different places: ROS headers, PTS, or `GstReferenceTimestampMeta`. Making this **configurable** lets pipelines pick the right truth source.
2. **Raw metadata transport.** We often need to move **binary payloads** (e.g., ONVIF XML, detection blobs) beside video. `rosrawsrc/sink` provide a clean, typed way to move these bytes between ROS and GStreamer, keeping the door open for sync with video.

---

## What’s in this MR

### 1) Sink-side timestamping is configurable (base class)

**New properties on all ROS sinks (via `RosBaseSink`):**

* `timestamp-mode` (`ros-offset` | `reference` | `pts`)
  * `ros-offset` (default): previous behavior (ROS clock → PTS adjusted by base time and ROS clock offset).
  * `reference`: take the time from `GstReferenceTimestampMeta` (if present).
  * `pts`: use the buffer PTS verbatim.
* `timestamp-conversion-mode` (`none` | `ntp2unix`)
  * Optional post-selection conversion (e.g., convert NTP→UNIX).

> Applies uniformly to `rosimagesink`, `rostextsink`, and the new `rosrawsink`.

### 2) Source-side stamping & optional reference meta attachment (base class)

**New property on all ROS sources (via `RosBaseSrc`):**

* `attach-reference-timestamp` (bool, default `false`)
  * When `true`, the source attaches **`GstReferenceTimestampMeta`** with caps **`timestamp/x-unix`** and the message time.
  * All stamping is routed through a new helper `set_timestamps(...)` so sources don’t duplicate logic.

> `rosimagesrc` and `rostextsrc` updated to use `set_timestamps(...)`. `rostextsrc` (strings have no header) now timestamps using `node->now()` and can optionally attach reference meta when requested.

### 3) New raw metadata bridge

**Elements:**

* `rosrawsrc` (caps: `application/x-onvif-metadata, format=xml, type=metadata`)
  * Subscribes to a ROS raw byte stream and produces `GstBuffer`s.
* `rosrawsink` (caps: `application/x-onvif-metadata`)
  * Consumes `GstBuffer`s and publishes a ROS raw byte stream.

**Message type:**

* Introduces **`gst_msgs/StreamStampedData`**

  ```cpp
  std_msgs/Header header
  uint8[] data
  ```
* `rosrawsrc/sink` use `gst_msgs::msg::StreamStampedData` (with header timestamps).

---

## How it fits together (common scenarios)

### A) RTSP/ONVIF pipeline using reference timestamps

* **Source side** (optional): set `attach-reference-timestamp=true` on `ros*src` to attach `timestamp/x-unix` meta.
* **Sink side**: set `timestamp-mode=reference`.
* **Conversion**: if your reference meta is NTP-based (e.g., from RTSP elements), enable `timestamp-conversion-mode=ntp2unix`. If your reference meta is already UNIX (e.g., from `ros*src` with `attach-reference-timestamp=true`), keep `timestamp-conversion-mode=none`.

### B) PTS-driven stamping (e.g., `rtponvifparse` put the authoritative clock in PTS)

* **Sink side**: `timestamp-mode=pts`, typically with `timestamp-conversion-mode=ntp2unix`.

### C) Legacy/default behavior

* Do nothing; defaults keep previous behavior: `timestamp-mode=ros-offset` + `timestamp-conversion-mode=none`.

---

## Example

RTSP server (video) with reference timestamps and metadata

```cpp
 gst_rtsp_media_factory_set_launch(
      factory,
      "( "
      // Video transport
      "rosimagesrc ros-topic=/test/image attach-reference-timestamp=true time-caps=timestamp/x-unix "
      "! queue "
      "! videoconvert "
      "! videoscale "
      "! video/x-raw,format=I420 "
      "! x264enc tune=zerolatency key-int-max=1 intra-refresh=true "
      "! rtph264pay pt=96 "
      "! rtponviftimestamp use-reference-timestamps=true name=pay0 "
      // Metadata transport
      "rosrawsrc ros-topic=/test/detections_raw attach-reference-timestamp=true time-caps=timestamp/x-unix "
      "! queue "
      "! rtponvifmetadatapay "
      "! rtponviftimestamp use-reference-timestamps=true name=pay1 "
      ")"
    );
```

Client version

```bash
gst-launch-1.0 \
  rtspsrc location=rtsp://localhost:8554/test_video \
          onvif-mode=1 onvif-rate-control=0 latency=200 \
          buffer-mode=0 ntp-sync=false name=src \
  \
  src. ! application/x-rtp,media=application,encoding-name=VND.ONVIF.METADATA \
       ! queue \
       ! rtponvifparse \
       ! rtponvifmetadatadepay \
       ! queue \
       ! rosrawsink ros-topic=/received/meta_raw \
                     timestamp-mode=pts \
                     timestamp-conversion-mode=ntp2unix \
                     sync=false \
  \
  src. ! application/x-rtp,media=video \
       ! queue \
       ! rtponvifparse \
       ! rtph264depay \
       ! avdec_h264 \
       ! videoconvert \
       ! timeoverlay time-mode=0 show-times-as-dates=true \
                     datetime-format="%d.%m.%Y %H:%M:%S.%f" \
                     halignment=right valignment=bottom \
       ! rosimagesink ros-topic=/received/image \
                      timestamp-mode=pts \
                      timestamp-conversion-mode=ntp2unix \
                      sync=false
```

## Compatibility & defaults

* **Defaults preserve behavior:** `timestamp-mode=ros-offset`, `timestamp-conversion-mode=none`, `attach-reference-timestamp=false`.
* **GStreamer versions:**
  * **`gst_buffer_add_reference_timestamp_meta`** works on **1.18+** (so sources can attach meta).
  * If you rely on **`rtspsrc`** to inject reference meta, the convenient property is **1.20+**. Not required when sources attach meta themselves.
* **Metadata transport with ONVIF timestamps requires gst-plugins-rs**