### PR TITLE
GStreamer pkg-config fix for non-standard install layouts (Nix, Guix, etc.)

### DIFF
--- a/gst_bridge/CMakeLists.txt
+++ b/gst_bridge/CMakeLists.txt
@@ -159,6 +159,6 @@ ament_export_dependencies(
 )
 
 ament_package(
-  CONFIG_EXTRAS
+  CONFIG_EXTRAS cmake/gst_bridge-extras.cmake
 )
 

--- a/gst_bridge/cmake/gst_bridge-extras.cmake
+++ b/gst_bridge/cmake/gst_bridge-extras.cmake
@@ -1,0 +1,20 @@
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(gstreamer REQUIRED IMPORTED_TARGET gstreamer-1.0)
+  pkg_check_modules(gstreamer-base REQUIRED IMPORTED_TARGET gstreamer-base-1.0)
+  pkg_check_modules(gstreamer-app REQUIRED IMPORTED_TARGET gstreamer-app-1.0)
+  pkg_check_modules(gstreamer-audio REQUIRED IMPORTED_TARGET gstreamer-audio-1.0)
+  pkg_check_modules(gstreamer-video REQUIRED IMPORTED_TARGET gstreamer-video-1.0)
+
+  # Propagate GStreamer include dirs through ament's exported variables so that
+  # downstream packages using ament_target_dependencies(... gst_bridge) pick up
+  # the sub-module include paths (audio, video, etc.) that gst_bridge headers need.
+  list(APPEND gst_bridge_INCLUDE_DIRS
+    ${gstreamer_INCLUDE_DIRS}
+    ${gstreamer-base_INCLUDE_DIRS}
+    ${gstreamer-app_INCLUDE_DIRS}
+    ${gstreamer-audio_INCLUDE_DIRS}
+    ${gstreamer-video_INCLUDE_DIRS}
+  )
+  list(REMOVE_DUPLICATES gst_bridge_INCLUDE_DIRS)
+endif()


### PR DESCRIPTION
Hiya! I've been doing some experimental work trying to get our ROS stack to build on Nix. Because of the way nix isolates packages (and their headers) this work has resulted in us finding a lot of cmake intricacies that "just work" on ubuntu (but not on nix...).

## Problem

`gst_pipeline`, `gst_pipeline_plugins`, and `gst_pipeline_plugins_webrtc` fail to build on systems where GStreamer headers are not installed into a single flat include directory (e.g. Nix, Guix, Homebrew with separate prefixes).

The error looks like:

```
gst_bridge/gst_bridge.h:22:10: fatal error: gst/audio/audio-format.h: No such file or directory
```

## Root cause

`gst_bridge`'s public headers include headers from GStreamer sub-modules that downstream packages don't use directly:

```cpp
// gst_bridge/gst_bridge.h
#include <gst/audio/audio-format.h>   // from gstreamer-audio-1.0
#include <gst/video/video-format.h>   // from gstreamer-video-1.0
```

The downstream packages (`gst_pipeline`, `gst_pipeline_plugins`, `gst_pipeline_plugins_webrtc`) each have their own direct GStreamer dependencies that they correctly declare themselves (e.g. `gstreamer-1.0`, `gstreamer-rtp-1.0`, `gstreamer-sdp-1.0`). However, none of them use `gstreamer-audio-1.0` or `gstreamer-video-1.0` directly — they only need those headers because `gst_bridge`'s public API exposes them.

On Ubuntu/Debian all GStreamer headers land in a single `/usr/include/gstreamer-1.0/` directory, so the compiler finds them even without the correct pkg-config modules. On Nix (and similar), each package has its own isolated include path, so the headers are only found if the correct pkg-config modules are explicitly requested.

`gst_bridge` links against these modules (`PkgConfig::gstreamer-audio`, etc.) publicly in its own `CMakeLists.txt`. Normally CMake would propagate those include dirs transitively to downstream targets. However, ament's `ament_target_dependencies()` macro doesn't use CMake's native target transitivity — it reads from ament-exported variables (`gst_bridge_INCLUDE_DIRS`, `gst_bridge_LIBRARIES`), which only contain what was explicitly exported via `ament_export_include_directories()` and `ament_export_libraries()`. The GStreamer sub-module include paths were not part of those exports.

## Fix

Added `gst_bridge/cmake/gst_bridge-extras.cmake`, a cmake extras script that is automatically loaded when any package calls `find_package(gst_bridge)`. It:

1. Runs `pkg_check_modules` for each GStreamer sub-module to ensure the pkg-config variables are populated
2. Appends all GStreamer include dirs to `gst_bridge_INCLUDE_DIRS` so that ament's dependency resolution picks them up

This is wired in via `ament_package(CONFIG_EXTRAS cmake/gst_bridge-extras.cmake)` in `gst_bridge/CMakeLists.txt`.

Since the `gstreamer-audio` and `gstreamer-video` headers are part of `gst_bridge`'s public API surface, it is `gst_bridge`'s responsibility to ensure consumers can compile against them. The alternative — making every downstream package add `pkg_check_modules` for sub-modules it doesn't use directly — would leak `gst_bridge`'s implementation details and cause every new consumer to hit the same build failure.


## Testing
I've built this and run the examples in the nix environment and inside a normal jazzy container - both seem to work now.